### PR TITLE
fix: use correct docker dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Full instructions available at [blog.ktz.me](https://blog.ktz.me/i-need-your-hel
 ssh user@hostname
 
 # install a couple of dependencies (script tested on proxmox 8 + ubuntu 22.04)
-apt install docker jq bc intel-gpu-tools
+apt install docker.io jq bc intel-gpu-tools
 
 # clone the git repo with the script
 git clone https://github.com/ironicbadger/quicksync_calc.git


### PR DESCRIPTION
Fixes the install line in the `README.md` to use the open source docker dependency (`docker.io`) for Debian/Proxmox instead of the `docker` system tray package. See: https://superuser.com/questions/784258/whats-the-difference-between-docker-io-and-docker

Tested on Proxmox 8.0.3.