### PR TITLE
Fix docker install on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Full instructions available at [blog.ktz.me](https://blog.ktz.me/i-need-your-hel
 ssh user@hostname
 
 # install a couple of dependencies (script tested on proxmox 8 + ubuntu 22.04)
-apt install docker jq bc intel-gpu-tools
+apt install docker.io jq bc intel-gpu-tools
 
 # clone the git repo with the script
 git clone https://github.com/ironicbadger/quicksync_calc.git


### PR DESCRIPTION
The docker package in debianbuntu is actually `docker.io`.  The docker package is transitional to `wmdocker` which is totally unrelated to containers.