### PR TITLE
Fix for empty values - syntax error

### DIFF
--- a/quicksync-benchmark.sh
+++ b/quicksync-benchmark.sh
@@ -251,8 +251,19 @@ benchmarks(){
 
   #Calculate average Wattage
   if [ $1 != "h264_1080p_cpu" ]; then
-    total_watts=$(awk '{ print $5 }' $1.output | grep -Ev '^0|Power|gpu' | paste -s -d + - | bc)
-    total_count=$(awk '{ print $5 }' $1.output | grep -Ev '^0|Power|gpu' | wc -l)
+    total_watts=$(
+      awk '{ print $5 }' $1.output \
+      | grep -E '^[0-9.]+$' \
+      | grep -Ev '^(0(\.0+)?|Power|gpu)$' \
+      | paste -s -d+ - \
+      | bc
+    )
+    total_count=$(
+      awk '{ print $5 }' $1.output \
+      | grep -E '^[0-9.]+$' \
+      | grep -Ev '^(0(\.0+)?|Power|gpu)$' \
+      | wc -l
+    )
     avg_watts=$(echo "scale=2; $total_watts / $total_count" | bc -l)
   else
     avg_watts="N/A"
@@ -265,8 +276,11 @@ benchmarks(){
     avg_fps=$(echo "scale=2; $total_fps / $fps_count" | bc -l)
 
     #Calculate average speed
-    total_speed=$(grep -Eo 'speed=[0-9].[0-9].' $i | sed -e 's/speed=//' | paste -s -d + - | bc)
-    speed_count=$(grep -Eo 'speed=[0-9].[0-9].' $i | sed -e 's/speed=//' | wc -l)
+    total_speed=$(grep -Eo 'speed=[0-9]+(\.[0-9]+)?x' "$i" \
+      | sed -E 's/speed=([0-9.]+)x/\1/' \
+      | paste -s -d+ - \
+      | bc)
+    speed_count=$(grep -Eo 'speed=[0-9]+(\.[0-9]+)?x' "$i" | wc -l)
     avg_speed="$(echo "scale=2; $total_speed / $speed_count" | bc -l)x"
 
     #Get Bitrate of file


### PR DESCRIPTION
Was getting errors due to blank values until I made the changes in the PR.

```
[1/5] H.264 1080p (CPU)         (expected: ~60-90s)
       Done!
[2/5] H.264 1080p (QSV)         (expected: ~15-20s)
(standard_in) 1: syntax error
(standard_in) 1: syntax error
```
```
++ echo 'DEBUG: total_speed='\'''\'', speed_count='\''0'\'''
DEBUG: total_speed='', speed_count='0'
+++ echo 'scale=2;  / 0'
+++ bc -l
(standard_in) 1: syntax error
```

I'm creating this PR in case anyone would like to try it out and confirm it works for them as well. 

One thing I am noticing is that I keep getting wattages under 1. 

```
CPU                              TEST            FILE                        BITRATE     TIME     AVG_FPS  AVG_SPEED  AVG_WATTS
 Intel(R) Core(TM) Ultra 7 265K  h264_1080p_cpu  ribblehead_1080p_h264       18952 kb/s  16.891s  173.72   5.76x      N/A
 Intel(R) Core(TM) Ultra 7 265K  h264_1080p      ribblehead_1080p_h264       18952 kb/s  7.236s   469.23   15.39x     .34
 Intel(R) Core(TM) Ultra 7 265K  h264_4k         ribblehead_4k_h264          46881 kb/s  38.538s  86.10    2.85x      .24
 Intel(R) Core(TM) Ultra 7 265K  hevc_8bit       ribblehead_1080p_hevc_8bit  14947 kb/s  7.519s   449.92   14.82x     .21
 Intel(R) Core(TM) Ultra 7 265K  hevc_4k_10bit   ribblehead_4k_hevc_10bit    44617 kb/s  82.870s  41.66    1.37x      .34

```

the output logs look like so..

```
 Freq MHz      IRQ RC6     Power W             RCS             BCS             VCS            VECS             CCS 
 req  act       /s   %   gpu   pkg       %  se  wa       %  se  wa       %  se  wa       %  se  wa       %  se  wa 
 501    0       91   0  0.29 40.78    0.00   0   0    0.00   0   0    0.00   0   0    0.00   0   0    0.00   0   0 
 550   52      369   0  0.32 49.91    0.00   0   0    0.00   0   0    0.00   0   0    0.00   0   0    0.00   0   0 
 567    0      387   0  0.32 65.86    0.00   0   0    0.00   0   0    0.00   0   0    0.00   0   0    0.00   0   0 
```

So not sure if this is normal or way too low. 