### PR TITLE
Use `/usr/bin/env` in script shebang

### DIFF
--- a/quicksync-benchmark.sh
+++ b/quicksync-benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Intel Quick Sync Video Benchmark
 # https://github.com/ironicbadger/quicksync_calc


### PR DESCRIPTION
This works nicer with NixOS so the script can figure out where the `bash` executable is