### PR TITLE
Use dark theme for system elements on a page

### DIFF
--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -48,6 +48,7 @@ const { title } = Astro.props;
 
       body {
         min-height: 100vh;
+        color-scheme: dark;
       }
 
       a {


### PR DESCRIPTION
Use dark theme for system elements like scroll bars or checkboxes.

Before:

<img width="3200" height="1982" alt="CleanShot 2025-12-05 at 17 49 07" src="https://github.com/user-attachments/assets/61b826f3-c9c5-4a6c-9ff4-7bbed27e0fcf" />


After:

<img width="3200" height="1982" alt="CleanShot 2025-12-05 at 17 50 06" src="https://github.com/user-attachments/assets/bbf31a28-c0af-410e-80e9-308d25aad31f" />
