### PR TITLE
Add CPU generation detail pages with rich architecture data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ comments.pkl
 secrets.yaml
 node_modules/
 .wrangler/
+.dev.vars

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -55,6 +55,9 @@ app.get('/', (c) => {
       'GET /api/stats/summary': 'Get summary statistics',
       'GET /api/scores': 'Get CPU scores with methodology',
       'GET /api/scores/for-results': 'Get score lookup map for all CPUs',
+      'GET /api/results/generation-detail': 'Get comprehensive data for a generation page',
+      'GET /api/results/architectures': 'Get all CPU architectures with metadata',
+      'GET /api/results/arc-models': 'Get Arc GPU models with individual stats',
     },
   });
 });

--- a/api/src/lib/cpu-parser.ts
+++ b/api/src/lib/cpu-parser.ts
@@ -3,6 +3,25 @@
  * Handles both legacy naming (i5-12500) and new naming (Core Ultra 7 265K).
  */
 
+/**
+ * Blocklist patterns for invalid/virtual CPUs that should be rejected.
+ */
+const CPU_BLOCKLIST: RegExp[] = [
+  /QEMU/i,
+  /Virtual/i,
+  /VMware/i,
+  /VirtualBox/i,
+  /Hyper-V/i,
+  /\bKVM\b/i,
+];
+
+/**
+ * Check if a CPU string matches the blocklist (virtual/invalid CPUs).
+ */
+export function isBlockedCPU(cpuRaw: string): boolean {
+  return CPU_BLOCKLIST.some(pattern => pattern.test(cpuRaw));
+}
+
 export interface CPUInfo {
   brand: string | null;      // i3, i5, i7, i9, Ultra 5, Ultra 7, etc.
   model: string | null;      // 12500, 265K, etc.

--- a/api/src/routes/results.ts
+++ b/api/src/routes/results.ts
@@ -789,4 +789,605 @@ results.get('/cpu-stats', async (c) => {
   });
 });
 
+// Get comprehensive detail for a single generation (for generation detail page)
+results.get('/generation-detail', async (c) => {
+  const db = getDb(c.env);
+  const vendor = c.req.query('vendor') || 'intel';
+  const genParam = c.req.query('generation'); // Can be "8", "12", "ultra-1", "ultra-2"
+  const baselineGen = 8;
+
+  if (!genParam) {
+    return c.json({ success: false, error: 'generation parameter required' }, 400);
+  }
+
+  // Handle special generation identifiers
+  let generationFilter: { type: 'generation' | 'architecture'; values: (number | string)[] };
+  let displayName: string;
+
+  if (genParam === 'ultra-1') {
+    generationFilter = { type: 'architecture', values: ['Meteor Lake'] };
+    displayName = 'Core Ultra Series 1';
+  } else if (genParam === 'ultra-2') {
+    generationFilter = { type: 'architecture', values: ['Arrow Lake', 'Lunar Lake'] };
+    displayName = 'Core Ultra Series 2';
+  } else if (genParam === 'arc-alchemist') {
+    generationFilter = { type: 'architecture', values: ['Arc Alchemist'] };
+    displayName = 'Arc Alchemist';
+  } else if (genParam === 'arc-battlemage') {
+    generationFilter = { type: 'architecture', values: ['Arc Battlemage'] };
+    displayName = 'Arc Battlemage';
+  } else if (genParam === 'arc') {
+    generationFilter = { type: 'architecture', values: ['Arc Alchemist', 'Arc Battlemage'] };
+    displayName = 'Intel Arc';
+  } else {
+    const gen = parseInt(genParam, 10);
+    if (isNaN(gen)) {
+      return c.json({ success: false, error: 'Invalid generation' }, 400);
+    }
+    generationFilter = { type: 'generation', values: [gen] };
+    displayName = `${gen}th Gen`;
+  }
+
+  // Build filter clause
+  const filterClause = generationFilter.type === 'generation'
+    ? `cpu_generation IN (${generationFilter.values.map(() => '?').join(',')})`
+    : `architecture IN (${generationFilter.values.map(() => '?').join(',')})`;
+
+  // Map generation numbers to architecture names for querying cpu_architectures
+  // This handles the case where multiple die variants exist for a generation
+  const genToArchMap: Record<number, string[]> = {
+    6: ['Skylake'],
+    7: ['Kaby Lake'],
+    8: ['Coffee Lake'],
+    9: ['Coffee Lake Refresh'],
+    10: ['Comet Lake', 'Ice Lake'],
+    11: ['Rocket Lake', 'Tiger Lake'],
+    12: ['Alder Lake'],
+    13: ['Raptor Lake'],
+    14: ['Raptor Lake Refresh'],
+  };
+
+  // Fetch ALL architecture variants for this generation (not just one)
+  // For generations 12-14, there may be multiple die variants (e.g., UHD 730 vs UHD 770)
+  let archMetadataQuery: string;
+  let archMetadataArgs: (string | number)[];
+
+  if (generationFilter.type === 'generation') {
+    const gen = generationFilter.values[0] as number;
+    const archNames = genToArchMap[gen] || [];
+    if (archNames.length > 0) {
+      archMetadataQuery = `SELECT * FROM cpu_architectures WHERE vendor = ? AND architecture IN (${archNames.map(() => '?').join(',')}) ORDER BY sort_order`;
+      archMetadataArgs = [vendor, ...archNames];
+    } else {
+      // Fallback: try pattern matching for unknown generations
+      archMetadataQuery = `SELECT DISTINCT * FROM cpu_architectures WHERE vendor = ? AND pattern LIKE '%' || ? || '%' ORDER BY sort_order`;
+      archMetadataArgs = [vendor, `-${gen}`];
+    }
+  } else {
+    archMetadataQuery = `SELECT * FROM cpu_architectures WHERE vendor = ? AND architecture IN (${generationFilter.values.map(() => '?').join(',')}) ORDER BY sort_order`;
+    archMetadataArgs = [vendor, ...generationFilter.values];
+  }
+
+  const [archMetadata, statsResult, overallResult, cpuModelsResult, baselineResult, baselineByTestResult, timelineResult] = await Promise.all([
+    // Architecture metadata
+    db.execute({
+      sql: archMetadataQuery,
+      args: archMetadataArgs,
+    }),
+    // Stats per test type
+    db.execute({
+      sql: `
+        SELECT
+          test_name,
+          COUNT(*) as result_count,
+          ROUND(AVG(avg_fps), 1) as avg_fps,
+          ROUND(MIN(avg_fps), 1) as min_fps,
+          ROUND(MAX(avg_fps), 1) as max_fps,
+          ROUND(AVG(CASE WHEN avg_watts > 0 THEN avg_watts ELSE NULL END), 1) as avg_watts,
+          ROUND(AVG(CASE WHEN fps_per_watt > 0 THEN fps_per_watt ELSE NULL END), 2) as fps_per_watt,
+          ROUND(AVG(avg_speed), 2) as avg_speed
+        FROM benchmark_results
+        WHERE vendor = ? AND ${filterClause}
+        GROUP BY test_name
+        ORDER BY test_name
+      `,
+      args: [vendor, ...generationFilter.values],
+    }),
+    // Overall stats
+    db.execute({
+      sql: `
+        SELECT
+          COUNT(*) as total_results,
+          COUNT(DISTINCT cpu_raw) as unique_cpus,
+          ROUND(AVG(avg_fps), 1) as avg_fps,
+          ROUND(AVG(CASE WHEN avg_watts > 0 THEN avg_watts ELSE NULL END), 1) as avg_watts,
+          ROUND(AVG(CASE WHEN fps_per_watt > 0 THEN fps_per_watt ELSE NULL END), 2) as fps_per_watt
+        FROM benchmark_results
+        WHERE vendor = ? AND ${filterClause}
+      `,
+      args: [vendor, ...generationFilter.values],
+    }),
+    // CPU models in this generation with stats
+    db.execute({
+      sql: `
+        SELECT
+          cpu_raw,
+          COUNT(*) as result_count,
+          ROUND(AVG(avg_fps), 1) as avg_fps,
+          ROUND(AVG(CASE WHEN fps_per_watt > 0 THEN fps_per_watt ELSE NULL END), 2) as fps_per_watt
+        FROM benchmark_results
+        WHERE vendor = ? AND ${filterClause}
+        GROUP BY cpu_raw
+        ORDER BY avg_fps DESC
+      `,
+      args: [vendor, ...generationFilter.values],
+    }),
+    // Baseline (8th gen) overall stats for comparison
+    db.execute({
+      sql: `
+        SELECT
+          ROUND(AVG(avg_fps), 1) as avg_fps,
+          ROUND(AVG(CASE WHEN avg_watts > 0 THEN avg_watts ELSE NULL END), 1) as avg_watts,
+          ROUND(AVG(CASE WHEN fps_per_watt > 0 THEN fps_per_watt ELSE NULL END), 2) as fps_per_watt
+        FROM benchmark_results
+        WHERE vendor = ? AND cpu_generation = ?
+      `,
+      args: [vendor, baselineGen],
+    }),
+    // Baseline (8th gen) stats per test type for charts
+    db.execute({
+      sql: `
+        SELECT
+          test_name,
+          ROUND(AVG(avg_fps), 1) as avg_fps,
+          ROUND(AVG(CASE WHEN avg_watts > 0 THEN avg_watts ELSE NULL END), 1) as avg_watts,
+          ROUND(AVG(CASE WHEN fps_per_watt > 0 THEN fps_per_watt ELSE NULL END), 2) as fps_per_watt
+        FROM benchmark_results
+        WHERE vendor = ? AND cpu_generation = ?
+        GROUP BY test_name
+        ORDER BY test_name
+      `,
+      args: [vendor, baselineGen],
+    }),
+    // All architectures for timeline (ordered by sort_order)
+    db.execute({
+      sql: `
+        SELECT DISTINCT
+          architecture,
+          codename,
+          release_year,
+          sort_order,
+          igpu_name,
+          igpu_codename,
+          process_nm,
+          max_p_cores,
+          max_e_cores,
+          tdp_range,
+          die_layout,
+          gpu_eu_count,
+          h264_encode,
+          hevc_8bit_encode,
+          hevc_10bit_encode,
+          vp9_encode,
+          av1_encode
+        FROM cpu_architectures
+        WHERE vendor = ?
+        ORDER BY sort_order
+      `,
+      args: [vendor],
+    }),
+  ]);
+
+  const overall = overallResult.rows[0] || {};
+  const baseline = baselineResult.rows[0] || {};
+
+  // Get all architecture variants for this generation
+  // For 12th-14th gen, there may be multiple die variants (lower-tier vs K-series)
+  const archVariants = archMetadata.rows.map((row: Record<string, unknown>) => ({
+    name: row.architecture as string || null,
+    codename: row.codename as string || null,
+    pattern: row.pattern as string || null,
+    release_year: row.release_year as number || null,
+    igpu_name: row.igpu_name as string || null,
+    igpu_codename: row.igpu_codename as string || null,
+    process_nm: row.process_nm as string || null,
+    max_p_cores: row.max_p_cores as number || null,
+    max_e_cores: row.max_e_cores as number || null,
+    tdp_range: row.tdp_range as string || null,
+    die_layout: row.die_layout as string || null,
+    gpu_eu_count: row.gpu_eu_count as string || null,
+    h264_encode: !!row.h264_encode,
+    hevc_8bit_encode: !!row.hevc_8bit_encode,
+    hevc_10bit_encode: !!row.hevc_10bit_encode,
+    vp9_encode: !!row.vp9_encode,
+    av1_encode: !!row.av1_encode,
+  }));
+
+  // Primary architecture info (first/highest-tier variant for backwards compatibility)
+  const archInfo = archMetadata.rows[archMetadata.rows.length - 1] || {};
+
+  // Check if generation has multiple die variants with different iGPUs
+  const uniqueIgpus = [...new Set(archVariants.map(v => v.igpu_name).filter(Boolean))];
+  const hasMultipleVariants = uniqueIgpus.length > 1;
+
+  // Build timeline data
+  interface TimelineEntry {
+    identifier: string;
+    name: string;
+    codename: string;
+    release_year: number;
+    sort_order: number;
+  }
+
+  const timelineEntries: TimelineEntry[] = [];
+  const seenArchitectures = new Set<string>();
+  let hasArc = false;
+
+  for (const row of timelineResult.rows) {
+    const arch = row.architecture as string;
+    if (seenArchitectures.has(arch)) continue;
+    seenArchitectures.add(arch);
+
+    // Map architectures to generation identifiers
+    let identifier: string;
+    if (arch === 'Meteor Lake') {
+      identifier = 'ultra-1';
+    } else if (arch === 'Arrow Lake' || arch === 'Lunar Lake') {
+      // Skip Lunar Lake in timeline (combined with Arrow Lake)
+      if (arch === 'Lunar Lake') continue;
+      identifier = 'ultra-2';
+    } else if (arch.includes('Arc')) {
+      // All Arc GPUs combined into single "arc" entry
+      hasArc = true;
+      continue; // Skip individual Arc entries, we'll add one combined entry at the end
+    } else {
+      // Extract generation number from sort_order (roughly maps to gen)
+      const sortOrder = row.sort_order as number;
+      // Map sort_order to generation: 20-29=2, 30-39=3, ..., 140-149=14
+      // Use Math.round(sortOrder / 10) to handle cases like 119->12, 129->13, 139->14
+      const gen = Math.round(sortOrder / 10);
+      // Start timeline at 6th gen (skip older generations)
+      if (gen < 6 || gen > 14) continue;
+      identifier = gen.toString();
+    }
+
+    timelineEntries.push({
+      identifier,
+      name: arch,
+      codename: row.codename as string,
+      release_year: row.release_year as number,
+      sort_order: row.sort_order as number,
+    });
+  }
+
+  // Add single combined Arc entry at the end if any Arc GPUs exist
+  if (hasArc) {
+    timelineEntries.push({
+      identifier: 'arc',
+      name: 'Intel Arc',
+      codename: 'Arc',
+      release_year: 2022,
+      sort_order: 9999, // Place at end
+    });
+  }
+
+  // Deduplicate timeline entries by identifier
+  const uniqueTimeline = timelineEntries.reduce((acc, entry) => {
+    if (!acc.find(e => e.identifier === entry.identifier)) {
+      acc.push(entry);
+    }
+    return acc;
+  }, [] as TimelineEntry[]);
+
+  // Find current position in timeline
+  const currentPosition = uniqueTimeline.findIndex(e => e.identifier === genParam);
+
+  // Sort test names
+  const allTests = sortTestNames((statsResult.rows as Array<Record<string, unknown>>).map(r => r.test_name as string));
+
+  // Calculate baseline comparison
+  const baselineAvgFps = (baseline.avg_fps as number) || 0;
+  const baselineFpsPerWatt = (baseline.fps_per_watt as number) || 0;
+  const currentAvgFps = (overall.avg_fps as number) || 0;
+  const currentFpsPerWatt = (overall.fps_per_watt as number) || 0;
+
+  const fpsDiffPercent = baselineAvgFps > 0
+    ? Math.round(((currentAvgFps - baselineAvgFps) / baselineAvgFps) * 100)
+    : null;
+  const efficiencyDiffPercent = baselineFpsPerWatt > 0
+    ? Math.round(((currentFpsPerWatt - baselineFpsPerWatt) / baselineFpsPerWatt) * 100)
+    : null;
+
+  return c.json({
+    success: true,
+    generation: genParam,
+    display_name: displayName,
+    // Primary architecture (highest-tier variant for backwards compatibility)
+    architecture: {
+      name: archInfo.architecture || null,
+      codename: archInfo.codename || null,
+      release_year: archInfo.release_year || null,
+      igpu_name: archInfo.igpu_name || null,
+      igpu_codename: archInfo.igpu_codename || null,
+      process_nm: archInfo.process_nm || null,
+      max_p_cores: archInfo.max_p_cores || null,
+      max_e_cores: archInfo.max_e_cores || null,
+      tdp_range: archInfo.tdp_range || null,
+      die_layout: archInfo.die_layout || null,
+      gpu_eu_count: archInfo.gpu_eu_count || null,
+    },
+    // All architecture variants (for generations with multiple die variants)
+    architecture_variants: archVariants,
+    has_multiple_variants: hasMultipleVariants,
+    codec_support: {
+      h264_encode: !!archInfo.h264_encode,
+      hevc_8bit_encode: !!archInfo.hevc_8bit_encode,
+      hevc_10bit_encode: !!archInfo.hevc_10bit_encode,
+      vp9_encode: !!archInfo.vp9_encode,
+      av1_encode: !!archInfo.av1_encode,
+    },
+    benchmark_stats: {
+      total_results: (overall.total_results as number) || 0,
+      unique_cpus: (overall.unique_cpus as number) || 0,
+      avg_fps: currentAvgFps,
+      avg_watts: overall.avg_watts || null,
+      fps_per_watt: currentFpsPerWatt,
+      by_test: allTests.map(testName => {
+        const testData = (statsResult.rows as Array<Record<string, unknown>>).find(r => r.test_name === testName);
+        return {
+          test_name: testName,
+          result_count: (testData?.result_count as number) || 0,
+          avg_fps: (testData?.avg_fps as number) || 0,
+          min_fps: (testData?.min_fps as number) || 0,
+          max_fps: (testData?.max_fps as number) || 0,
+          avg_watts: testData?.avg_watts || null,
+          fps_per_watt: testData?.fps_per_watt || null,
+          avg_speed: testData?.avg_speed || null,
+        };
+      }),
+    },
+    cpu_models: cpuModelsResult.rows.map((row: Record<string, unknown>) => ({
+      cpu_raw: row.cpu_raw as string,
+      result_count: row.result_count as number,
+      avg_fps: row.avg_fps as number,
+      fps_per_watt: row.fps_per_watt as number | null,
+    })),
+    timeline: {
+      all_generations: uniqueTimeline,
+      current_position: currentPosition,
+      previous: currentPosition > 0 ? uniqueTimeline[currentPosition - 1] : null,
+      next: currentPosition < uniqueTimeline.length - 1 ? uniqueTimeline[currentPosition + 1] : null,
+    },
+    baseline_comparison: {
+      baseline_generation: baselineGen,
+      fps_diff_percent: fpsDiffPercent,
+      efficiency_diff_percent: efficiencyDiffPercent,
+    },
+    baseline_by_test: allTests.map(testName => {
+      const testData = (baselineByTestResult.rows as Array<Record<string, unknown>>).find(r => r.test_name === testName);
+      return {
+        test_name: testName,
+        avg_fps: (testData?.avg_fps as number) || 0,
+        avg_watts: testData?.avg_watts || null,
+        fps_per_watt: testData?.fps_per_watt || null,
+      };
+    }),
+  });
+});
+
+// Get all architectures with metadata (for timeline and overview)
+results.get('/architectures', async (c) => {
+  const db = getDb(c.env);
+  const vendor = c.req.query('vendor') || 'intel';
+
+  const result = await db.execute({
+    sql: `
+      SELECT DISTINCT
+        architecture,
+        codename,
+        release_year,
+        release_quarter,
+        sort_order,
+        igpu_name,
+        igpu_codename,
+        process_nm,
+        max_p_cores,
+        max_e_cores,
+        tdp_range,
+        die_layout,
+        gpu_eu_count,
+        h264_encode,
+        hevc_8bit_encode,
+        hevc_10bit_encode,
+        vp9_encode,
+        av1_encode
+      FROM cpu_architectures
+      WHERE vendor = ?
+      ORDER BY sort_order
+    `,
+    args: [vendor],
+  });
+
+  // Deduplicate by architecture name (some have multiple patterns)
+  const seen = new Set<string>();
+  const architectures = result.rows.filter((row: Record<string, unknown>) => {
+    const arch = row.architecture as string;
+    if (seen.has(arch)) return false;
+    seen.add(arch);
+    return true;
+  });
+
+  return c.json({
+    success: true,
+    architectures: architectures.map((row: Record<string, unknown>) => ({
+      architecture: row.architecture,
+      codename: row.codename,
+      release_year: row.release_year,
+      release_quarter: row.release_quarter,
+      sort_order: row.sort_order,
+      igpu_name: row.igpu_name,
+      igpu_codename: row.igpu_codename,
+      process_nm: row.process_nm,
+      max_p_cores: row.max_p_cores,
+      max_e_cores: row.max_e_cores,
+      tdp_range: row.tdp_range,
+      die_layout: row.die_layout,
+      gpu_eu_count: row.gpu_eu_count,
+      codec_support: {
+        h264_encode: !!row.h264_encode,
+        hevc_8bit_encode: !!row.hevc_8bit_encode,
+        hevc_10bit_encode: !!row.hevc_10bit_encode,
+        vp9_encode: !!row.vp9_encode,
+        av1_encode: !!row.av1_encode,
+      },
+    })),
+  });
+});
+
+// Get Arc GPU models with individual stats (not merged)
+results.get('/arc-models', async (c) => {
+  const db = getDb(c.env);
+  const vendor = c.req.query('vendor') || 'intel';
+  const archFilter = c.req.query('architecture'); // Optional: "Alchemist" or "Battlemage"
+
+  // Build architecture filter
+  let archCondition = `architecture LIKE 'Arc%'`;
+  const args: (string | number)[] = [vendor];
+
+  if (archFilter) {
+    const archs = archFilter.split(',').map((a: string) => a.trim()).filter((a: string) => a);
+    if (archs.length > 0) {
+      archCondition = `architecture IN (${archs.map(() => '?').join(',')})`;
+      args.push(...archs);
+    }
+  }
+
+  const [modelsResult, archMetadata] = await Promise.all([
+    // Get individual GPU models with stats
+    db.execute({
+      sql: `
+        SELECT
+          cpu_raw as model_name,
+          architecture,
+          test_name,
+          COUNT(*) as result_count,
+          ROUND(AVG(avg_fps), 1) as avg_fps,
+          ROUND(MIN(avg_fps), 1) as min_fps,
+          ROUND(MAX(avg_fps), 1) as max_fps,
+          ROUND(AVG(CASE WHEN avg_watts > 0 THEN avg_watts ELSE NULL END), 1) as avg_watts,
+          ROUND(AVG(CASE WHEN fps_per_watt > 0 THEN fps_per_watt ELSE NULL END), 2) as fps_per_watt,
+          ROUND(AVG(avg_speed), 2) as avg_speed
+        FROM benchmark_results
+        WHERE vendor = ? AND ${archCondition}
+        GROUP BY cpu_raw, test_name
+        ORDER BY cpu_raw, test_name
+      `,
+      args,
+    }),
+    // Get architecture metadata
+    db.execute({
+      sql: `
+        SELECT DISTINCT
+          architecture,
+          codename,
+          release_year,
+          igpu_name,
+          igpu_codename,
+          process_nm,
+          tdp_range,
+          die_layout,
+          gpu_eu_count,
+          h264_encode,
+          hevc_8bit_encode,
+          hevc_10bit_encode,
+          vp9_encode,
+          av1_encode
+        FROM cpu_architectures
+        WHERE vendor = ? AND architecture LIKE 'Arc%'
+        ORDER BY sort_order
+      `,
+      args: [vendor],
+    }),
+  ]);
+
+  // Group results by model
+  const modelMap = new Map<string, {
+    model_name: string;
+    architecture: string;
+    total_results: number;
+    by_test: Array<{
+      test_name: string;
+      result_count: number;
+      avg_fps: number;
+      min_fps: number;
+      max_fps: number;
+      avg_watts: number | null;
+      fps_per_watt: number | null;
+      avg_speed: number | null;
+    }>;
+  }>();
+
+  for (const row of modelsResult.rows) {
+    const modelName = row.model_name as string;
+    if (!modelMap.has(modelName)) {
+      modelMap.set(modelName, {
+        model_name: modelName,
+        architecture: row.architecture as string,
+        total_results: 0,
+        by_test: [],
+      });
+    }
+
+    const model = modelMap.get(modelName)!;
+    model.total_results += row.result_count as number;
+    model.by_test.push({
+      test_name: row.test_name as string,
+      result_count: row.result_count as number,
+      avg_fps: row.avg_fps as number,
+      min_fps: row.min_fps as number,
+      max_fps: row.max_fps as number,
+      avg_watts: row.avg_watts as number | null,
+      fps_per_watt: row.fps_per_watt as number | null,
+      avg_speed: row.avg_speed as number | null,
+    });
+  }
+
+  // Sort by test order within each model
+  for (const model of modelMap.values()) {
+    model.by_test = sortTestNames(model.by_test.map(t => t.test_name))
+      .map(testName => model.by_test.find(t => t.test_name === testName)!)
+      .filter(Boolean);
+  }
+
+  return c.json({
+    success: true,
+    architectures: archMetadata.rows.map((row: Record<string, unknown>) => ({
+      architecture: row.architecture,
+      codename: row.codename,
+      release_year: row.release_year,
+      igpu_name: row.igpu_name,
+      igpu_codename: row.igpu_codename,
+      process_nm: row.process_nm,
+      tdp_range: row.tdp_range,
+      die_layout: row.die_layout,
+      gpu_eu_count: row.gpu_eu_count,
+      codec_support: {
+        h264_encode: !!row.h264_encode,
+        hevc_8bit_encode: !!row.hevc_8bit_encode,
+        hevc_10bit_encode: !!row.hevc_10bit_encode,
+        vp9_encode: !!row.vp9_encode,
+        av1_encode: !!row.av1_encode,
+      },
+    })),
+    models: Array.from(modelMap.values()).sort((a, b) => {
+      // Sort by architecture first, then by model name
+      if (a.architecture !== b.architecture) {
+        return a.architecture.localeCompare(b.architecture);
+      }
+      return a.model_name.localeCompare(b.model_name);
+    }),
+    all_tests: sortTestNames(Array.from(new Set(modelsResult.rows.map((r: Record<string, unknown>) => r.test_name as string)))),
+  });
+});
+
 export default results;

--- a/quicksync-benchmark.sh
+++ b/quicksync-benchmark.sh
@@ -370,6 +370,16 @@ main(){
   cpuinfo_model="$(grep -m1 'model name' /proc/cpuinfo | cut -d':' -f2)"
   cpu_model="${cpuinfo_model:-1}"
 
+  # Check for virtual/emulated CPUs (not supported for benchmarking)
+  if echo "$cpu_model" | grep -qiE 'QEMU|Virtual|VMware|VirtualBox|Hyper-V|KVM'; then
+    echo ""
+    echo "ERROR: Virtual/emulated CPUs are not supported for benchmarking."
+    echo "Detected CPU: $cpu_model"
+    echo ""
+    echo "This benchmark requires real hardware with Intel Quick Sync Video support."
+    exit 1
+  fi
+
   echo ""
   echo "Running benchmarks (estimated total time: 5-7 minutes)"
   echo "======================================================="

--- a/scripts/cleanup-cpu-data.sql
+++ b/scripts/cleanup-cpu-data.sql
@@ -1,0 +1,60 @@
+-- Database cleanup script for CPU data validation
+-- Run this against the Turso database to clean up existing junk data
+
+-- 1. Delete entries with virtual/emulated CPUs
+DELETE FROM benchmark_results
+WHERE cpu_raw LIKE '%QEMU%'
+   OR cpu_raw LIKE '%Virtual%'
+   OR cpu_raw LIKE '%VMware%'
+   OR cpu_raw LIKE '%VirtualBox%'
+   OR cpu_raw LIKE '%Hyper-V%'
+   OR cpu_raw LIKE '% KVM %';
+
+-- 2. Normalize CPU strings: remove Intel(R), Core(TM), CPU, and frequency suffix
+-- This requires multiple UPDATE statements since SQLite lacks regex replace
+
+-- Remove "@ X.XXGHz" frequency suffix
+UPDATE benchmark_results
+SET cpu_raw = TRIM(SUBSTR(cpu_raw, 1, INSTR(cpu_raw, ' @') - 1))
+WHERE cpu_raw LIKE '% @%GHz%';
+
+-- Remove "(R)" markers
+UPDATE benchmark_results
+SET cpu_raw = REPLACE(cpu_raw, '(R)', '')
+WHERE cpu_raw LIKE '%(R)%';
+
+-- Remove "(TM)" markers
+UPDATE benchmark_results
+SET cpu_raw = REPLACE(cpu_raw, '(TM)', '')
+WHERE cpu_raw LIKE '%(TM)%';
+
+-- Remove "CPU" word
+UPDATE benchmark_results
+SET cpu_raw = REPLACE(cpu_raw, ' CPU ', ' ')
+WHERE cpu_raw LIKE '% CPU %';
+
+-- Remove trailing "CPU"
+UPDATE benchmark_results
+SET cpu_raw = TRIM(SUBSTR(cpu_raw, 1, LENGTH(cpu_raw) - 3))
+WHERE cpu_raw LIKE '% CPU';
+
+-- Collapse multiple spaces
+UPDATE benchmark_results
+SET cpu_raw = REPLACE(cpu_raw, '  ', ' ')
+WHERE cpu_raw LIKE '%  %';
+
+-- Final trim
+UPDATE benchmark_results
+SET cpu_raw = TRIM(cpu_raw);
+
+-- 3. Delete entries with NULL architecture (unrecognized CPUs)
+-- Review these first before deleting!
+-- SELECT DISTINCT cpu_raw, architecture FROM benchmark_results WHERE architecture IS NULL;
+
+DELETE FROM benchmark_results
+WHERE architecture IS NULL;
+
+-- 4. Verify cleanup results
+SELECT 'Remaining entries:' AS status, COUNT(*) AS count FROM benchmark_results;
+SELECT 'Distinct CPUs:' AS status, COUNT(DISTINCT cpu_raw) AS count FROM benchmark_results;
+SELECT 'Sample CPU names:' AS status, cpu_raw FROM benchmark_results GROUP BY cpu_raw LIMIT 10;

--- a/scripts/run-seed.js
+++ b/scripts/run-seed.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Run seed-architectures.sql against Turso database
+ * Usage: node run-seed.js <turso_url> <turso_token>
+ */
+
+const { createClient } = require('@libsql/client');
+const fs = require('fs');
+const path = require('path');
+
+const url = process.argv[2];
+const authToken = process.argv[3];
+
+if (!url || !authToken) {
+  console.error('Usage: node run-seed.js <turso_url> <turso_token>');
+  process.exit(1);
+}
+
+const client = createClient({ url, authToken });
+
+const sqlPath = path.join(__dirname, 'seed-architectures.sql');
+const sql = fs.readFileSync(sqlPath, 'utf8');
+
+// Split on semicolons, handling multi-line INSERT statements
+const statements = [];
+let current = '';
+
+for (const line of sql.split('\n')) {
+  const trimmed = line.trim();
+  // Skip pure comment lines
+  if (trimmed.startsWith('--')) continue;
+  // Skip empty lines
+  if (!trimmed) continue;
+
+  current += ' ' + trimmed;
+
+  // If line ends with semicolon, we have a complete statement
+  if (trimmed.endsWith(';')) {
+    statements.push(current.trim().slice(0, -1)); // Remove trailing semicolon
+    current = '';
+  }
+}
+
+// Add any remaining statement
+if (current.trim()) {
+  statements.push(current.trim());
+}
+
+(async () => {
+  console.log(`Executing ${statements.length} statements...`);
+  let success = 0;
+  let errors = 0;
+
+  for (const stmt of statements) {
+    if (!stmt) continue;
+    // Skip comment-only blocks
+    if (stmt.split('\n').every(line => line.trim().startsWith('--') || !line.trim())) continue;
+
+    try {
+      await client.execute(stmt + ';');
+      const preview = stmt.replace(/\n/g, ' ').substring(0, 60);
+      console.log(`OK: ${preview}...`);
+      success++;
+    } catch (e) {
+      const preview = stmt.replace(/\n/g, ' ').substring(0, 60);
+      console.error(`ERR: ${preview}... - ${e.message}`);
+      errors++;
+    }
+  }
+
+  console.log(`\nDone! ${success} succeeded, ${errors} failed.`);
+  process.exit(errors > 0 ? 1 : 0);
+})();

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -83,6 +83,16 @@ CREATE TABLE IF NOT EXISTS cpu_architectures (
     vp9_encode BOOLEAN DEFAULT 0,
     av1_encode BOOLEAN DEFAULT 0,
 
+    -- Integrated GPU info (for generation detail pages)
+    igpu_name TEXT,                  -- "Intel UHD 630", "Intel Xe Graphics", "Arc Graphics"
+    igpu_codename TEXT,              -- "Gen9.5", "Xe-LP", "Xe-LPG"
+    process_nm TEXT,                 -- "14nm", "Intel 7", "Intel 4" (TEXT for marketing names)
+    max_p_cores INTEGER,             -- Max performance cores for this architecture
+    max_e_cores INTEGER,             -- Max efficiency cores (NULL for pre-Alder Lake)
+    tdp_range TEXT,                  -- "35-125W", "15-45W"
+    die_layout TEXT,                 -- "Monolithic", "Hybrid (P+E cores)", "Chiplet (4 tiles)"
+    gpu_eu_count TEXT,               -- "24 EU", "32 EU", "128 EU"
+
     -- Vendor support
     vendor TEXT DEFAULT 'intel',
 

--- a/scripts/seed-architectures.sql
+++ b/scripts/seed-architectures.sql
@@ -9,194 +9,301 @@ DELETE FROM cpu_architectures WHERE vendor = 'intel';
 
 -- Sandy Bridge (2nd gen) - H.264 decode only, no hardware encode
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-2\d{3}', 'Sandy Bridge', 'SNB', 2011, 1, 20, 0, 0, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-2\d{3}', 'Sandy Bridge', 'SNB', 2011, 1, 20, 0, 0, 0, 0, 0,
+    'Intel HD Graphics 2000/3000', 'Gen6', '32nm', 4, NULL, '35-95W', 'Monolithic', '6-12 EU', 'intel');
 
 -- Ivy Bridge (3rd gen) - H.264 encode
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-3\d{3}', 'Ivy Bridge', 'IVB', 2012, 2, 30, 1, 0, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-3\d{3}', 'Ivy Bridge', 'IVB', 2012, 2, 30, 1, 0, 0, 0, 0,
+    'Intel HD Graphics 2500/4000', 'Gen7', '22nm', 4, NULL, '35-77W', 'Monolithic', '6-16 EU', 'intel');
 
 -- Haswell (4th gen) - H.264 encode
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-4\d{3}', 'Haswell', 'HSW', 2013, 2, 40, 1, 0, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-4\d{3}', 'Haswell', 'HSW', 2013, 2, 40, 1, 0, 0, 0, 0,
+    'Intel HD Graphics 4600', 'Gen7.5', '22nm', 4, NULL, '35-84W', 'Monolithic', '20 EU', 'intel');
 
 -- Broadwell (5th gen) - H.264 encode
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-5\d{3}', 'Broadwell', 'BDW', 2014, 4, 50, 1, 0, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-5\d{3}', 'Broadwell', 'BDW', 2014, 4, 50, 1, 0, 0, 0, 0,
+    'Intel HD Graphics 5500/6000', 'Gen8', '14nm', 4, NULL, '15-65W', 'Monolithic', '24-48 EU', 'intel');
 
 -- Skylake (6th gen) - H.264 encode, HEVC decode only
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-6\d{3}', 'Skylake', 'SKL', 2015, 3, 60, 1, 0, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-6\d{3}', 'Skylake', 'SKL', 2015, 3, 60, 1, 0, 0, 0, 0,
+    'Intel HD Graphics 530', 'Gen9', '14nm', 4, NULL, '35-91W', 'Monolithic', '24 EU', 'intel');
 
 -- Kaby Lake (7th gen) - H.264 + HEVC 8-bit encode
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-7\d{3}', 'Kaby Lake', 'KBL', 2017, 1, 70, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-7\d{3}', 'Kaby Lake', 'KBL', 2017, 1, 70, 1, 1, 0, 0, 0,
+    'Intel HD Graphics 630', 'Gen9.5', '14nm', 4, NULL, '35-91W', 'Monolithic', '24 EU', 'intel');
 
 -- Coffee Lake (8th gen) - H.264 + HEVC 8-bit encode
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-8\d{3}', 'Coffee Lake', 'CFL', 2018, 4, 80, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-8\d{3}', 'Coffee Lake', 'CFL', 2018, 4, 80, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics 630', 'Gen9.5', '14nm', 6, NULL, '35-95W', 'Monolithic', '24 EU', 'intel');
 
 -- Coffee Lake Refresh (9th gen) - H.264 + HEVC 8-bit encode
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-9\d{3}', 'Coffee Lake Refresh', 'CFL-R', 2019, 2, 90, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-9\d{3}', 'Coffee Lake Refresh', 'CFL-R', 2019, 2, 90, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics 630', 'Gen9.5', '14nm', 8, NULL, '35-95W', 'Monolithic', '24 EU', 'intel');
 
 -- Comet Lake (10th gen desktop) - H.264 + HEVC 8-bit encode
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-10\d{3}[A-Z]?$', 'Comet Lake', 'CML', 2020, 2, 100, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-10\d{3}[A-Z]?$', 'Comet Lake', 'CML', 2020, 2, 100, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics 630', 'Gen9.5', '14nm', 10, NULL, '35-125W', 'Monolithic', '24 EU', 'intel');
 
 -- Ice Lake (10th gen mobile - ends in G) - H.264 + HEVC 8-bit encode (10-bit decode only)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-10\d{2}G', 'Ice Lake', 'ICL', 2019, 3, 95, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-10\d{2}G', 'Ice Lake', 'ICL', 2019, 3, 95, 1, 1, 0, 0, 0,
+    'Intel Iris Plus Graphics', 'Gen11', '10nm', 4, NULL, '9-28W', 'Monolithic', '64 EU', 'intel');
 
 -- Tiger Lake (11th gen mobile - ends in G) - Full encode: H.264, HEVC 8/10-bit, VP9 (AV1 decode only)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-11\d{2}G', 'Tiger Lake', 'TGL', 2020, 3, 105, 1, 1, 1, 1, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-11\d{2}G', 'Tiger Lake', 'TGL', 2020, 3, 105, 1, 1, 1, 1, 0,
+    'Intel Iris Xe Graphics', 'Xe-LP', '10nm SuperFin', 4, NULL, '12-28W', 'Monolithic', '96 EU', 'intel');
 
 -- Rocket Lake (11th gen desktop) - Full encode: H.264, HEVC 8/10-bit, VP9 (AV1 decode only)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-11\d{3}', 'Rocket Lake', 'RKL', 2021, 1, 110, 1, 1, 1, 1, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[3579]-11\d{3}', 'Rocket Lake', 'RKL', 2021, 1, 110, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics 750', 'Xe', '14nm', 8, NULL, '35-125W', 'Monolithic', '32 EU', 'intel');
 
--- Alder Lake (12th gen) - Full encode: H.264, HEVC 8/10-bit, VP9 (AV1 decode only)
+-- Alder Lake (12th gen) - Split by die variant
+-- Lower-tier i3/i5 (i3-12100, i5-12400, i5-12500) use ADL-S E0 die with UHD 730 (24 EU)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-12\d{3}', 'Alder Lake', 'ADL', 2021, 4, 120, 1, 1, 1, 1, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[35]-12[1-5]\d{2}[^K]?$', 'Alder Lake', 'ADL-S (E0)', 2022, 1, 119, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics 730', 'Xe-LP', 'Intel 7', 6, 0, '35-65W', 'P-cores only (no E-cores)', '24 EU', 'intel');
 
--- Raptor Lake (13th gen) - Full encode: H.264, HEVC 8/10-bit, VP9 (AV1 decode only)
+-- Higher-tier 12th gen (i5-12600K+, i7, i9) use ADL-S C0 die with UHD 770 (32 EU) and hybrid architecture
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-13\d{3}', 'Raptor Lake', 'RPL', 2022, 4, 130, 1, 1, 1, 1, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[579]-12[6-9]\d{2}', 'Alder Lake', 'ADL-S (C0)', 2021, 4, 120, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics 770', 'Xe-LP', 'Intel 7', 8, 8, '65-125W', 'Hybrid (P+E cores)', '32 EU', 'intel');
 
--- Raptor Lake Refresh (14th gen) - Full encode: H.264, HEVC 8/10-bit, VP9 (AV1 decode only)
+-- Raptor Lake (13th gen) - Split by die variant
+-- Lower-tier i3/i5 (i3-13100, i5-13400, i5-13500) actually use Alder Lake B0 die with UHD 730 (24 EU)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i[3579]-14\d{3}', 'Raptor Lake Refresh', 'RPL-R', 2023, 4, 140, 1, 1, 1, 1, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[35]-13[1-5]\d{2}[^K]?$', 'Raptor Lake', 'RPL-S (B0/ADL die)', 2023, 1, 129, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics 730', 'Xe-LP', 'Intel 7', 6, 4, '35-65W', 'Hybrid (uses ADL silicon)', '24 EU', 'intel');
 
--- Intel Arc (discrete GPU) - FULL encode including AV1
+-- Higher-tier 13th gen (i5-13600K+, i7, i9) use true Raptor Lake die with UHD 770 (32 EU)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Arc A\d{3}', 'Arc Alchemist', 'DG2', 2022, 4, 145, 1, 1, 1, 1, 1, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[579]-13[6-9]\d{2}', 'Raptor Lake', 'RPL-S', 2022, 4, 130, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics 770', 'Xe-LP', 'Intel 7', 8, 16, '65-125W', 'Hybrid (P+E cores)', '32 EU', 'intel');
+
+-- Raptor Lake Refresh (14th gen) - Split by die variant
+-- Lower-tier i3/i5 (i3-14100, i5-14400, i5-14500) use Alder Lake B0 die with UHD 730 (24 EU)
+INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[35]-14[1-5]\d{2}[^K]?$', 'Raptor Lake Refresh', 'RPL-R (B0/ADL die)', 2024, 1, 139, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics 730', 'Xe-LP', 'Intel 7', 6, 4, '35-65W', 'Hybrid (uses ADL silicon)', '24 EU', 'intel');
+
+-- Higher-tier 14th gen (i5-14600K+, i7, i9) use true Raptor Lake die with UHD 770 (32 EU)
+INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i[579]-14[6-9]\d{2}', 'Raptor Lake Refresh', 'RPL-R', 2023, 4, 140, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics 770', 'Xe-LP', 'Intel 7', 8, 16, '65-125W', 'Hybrid (P+E cores)', '32 EU', 'intel');
+
+-- Intel Arc Alchemist (discrete GPU) - FULL encode including AV1
+INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Arc A\d{3}', 'Arc Alchemist', 'DG2', 2022, 4, 145, 1, 1, 1, 1, 1,
+    'Intel Arc A-Series', 'Xe-HPG', 'TSMC N6', NULL, NULL, '75-225W', 'Discrete GPU (ACM-G10/G11)', '128-512 EU', 'intel');
+
+-- Intel Arc Battlemage (discrete GPU) - FULL encode including AV1
+INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Arc B\d{3}', 'Arc Battlemage', 'BMG', 2024, 4, 147, 1, 1, 1, 1, 1,
+    'Intel Arc B-Series', 'Xe2-HPG', 'TSMC N4', NULL, NULL, '150W', 'Discrete GPU (BMG-G21)', '160 EU', 'intel');
 
 -- Meteor Lake (Core Ultra Series 1) - FULL encode including AV1
 -- Pattern matches: Core Ultra 5 125H, Core Ultra 7 155H, Core Ultra 9 185H, etc.
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Ultra [3579] 1\d{2}[HUP]?', 'Meteor Lake', 'MTL', 2023, 4, 150, 1, 1, 1, 1, 1, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Ultra [3579] 1\d{2}[HUP]?', 'Meteor Lake', 'MTL', 2023, 4, 150, 1, 1, 1, 1, 1,
+    'Intel Arc Graphics', 'Xe-LPG', 'Intel 4', 6, 8, '15-45W', 'Chiplet (4 tiles: Compute, SoC, GFX, I/O)', '128 EU', 'intel');
 
 -- Arrow Lake (Core Ultra Series 2 desktop) - FULL encode including AV1
 -- Pattern matches: Core Ultra 5 245K, Core Ultra 7 265K, Core Ultra 9 285K
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Ultra [3579] 2\d{2}[KFS]', 'Arrow Lake', 'ARL', 2024, 4, 200, 1, 1, 1, 1, 1, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Ultra [3579] 2\d{2}[KFS]', 'Arrow Lake', 'ARL', 2024, 4, 200, 1, 1, 1, 1, 1,
+    'Intel Arc Graphics', 'Xe2-LPG', 'Intel 20A / TSMC N3B', 8, 16, '125W', 'Chiplet (Compute + SoC tiles)', '64 EU', 'intel');
 
 -- Lunar Lake (Core Ultra Series 2 mobile) - FULL encode including AV1
 -- Pattern matches: Core Ultra 5 225V, Core Ultra 7 255V, Core Ultra 7 256V
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Ultra [3579] 2\d{2}[VU]', 'Lunar Lake', 'LNL', 2024, 3, 210, 1, 1, 1, 1, 1, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Ultra [3579] 2\d{2}[VU]', 'Lunar Lake', 'LNL', 2024, 3, 210, 1, 1, 1, 1, 1,
+    'Intel Arc Graphics', 'Xe2-LPG', 'TSMC N3B', 4, 4, '17-30W', 'Foveros 3D stacked (on-package LPDDR5X)', '64 EU', 'intel');
 
 -- Xeon patterns (common in servers running Jellyfin)
 -- Xeon E3 (Haswell through Coffee Lake era)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Xeon.*E3-1[23]\d{2}', 'Xeon E3', 'Various', 2015, 1, 55, 1, 0, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Xeon.*E3-1[23]\d{2}', 'Xeon E3', 'Various', 2015, 1, 55, 1, 0, 0, 0, 0,
+    'Intel HD Graphics P530/P630', 'Gen9', '14nm', 4, NULL, '35-80W', 'Monolithic', '24 EU', 'intel');
 
 -- Xeon E-2100/2200/2300 series (Coffee Lake era iGPU support)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Xeon.*E-2[123]\d{2}', 'Xeon E', 'CFL', 2018, 4, 85, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Xeon.*E-2[123]\d{2}', 'Xeon E', 'CFL', 2018, 4, 85, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics P630', 'Gen9.5', '14nm', 8, NULL, '35-95W', 'Monolithic', '24 EU', 'intel');
 
 -- Pentium Gold (8th gen+ with iGPU)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Pentium.*G[567]\d{3}', 'Pentium Gold', 'CFL', 2018, 4, 82, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Pentium.*G[567]\d{3}', 'Pentium Gold', 'CFL', 2018, 4, 82, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics 610', 'Gen9.5', '14nm', 2, NULL, '35-58W', 'Monolithic', '24 EU', 'intel');
 
 -- Celeron (various generations with iGPU)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Celeron.*G[4567]\d{3}', 'Celeron', 'Various', 2017, 1, 65, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Celeron.*G[4567]\d{3}', 'Celeron', 'Various', 2017, 1, 65, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics 610', 'Gen9.5', '14nm', 2, NULL, '35-58W', 'Monolithic', '12 EU', 'intel');
 
 -- Intel N-series (Alder Lake-N) - found in mini PCs
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('N[12]\d{2}', 'Alder Lake-N', 'ADL-N', 2023, 1, 125, 1, 1, 1, 1, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('N[12]\d{2}', 'Alder Lake-N', 'ADL-N', 2023, 1, 125, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics', 'Xe-LP', 'Intel 7', 0, 8, '6-15W', 'E-cores only (efficient)', '32 EU', 'intel');
 
 -- Intel Processor N-series (newer naming)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Processor N\d{3}', 'Alder Lake-N', 'ADL-N', 2023, 1, 126, 1, 1, 1, 1, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Processor N\d{3}', 'Alder Lake-N', 'ADL-N', 2023, 1, 126, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics', 'Xe-LP', 'Intel 7', 0, 8, '6-15W', 'E-cores only (efficient)', '32 EU', 'intel');
 
 -- Intel Core i3-N series (Alder Lake-N)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('i3-N\d{3}', 'Alder Lake-N', 'ADL-N', 2023, 1, 125, 1, 1, 1, 1, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('i3-N\d{3}', 'Alder Lake-N', 'ADL-N', 2023, 1, 125, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics', 'Xe-LP', 'Intel 7', 0, 8, '6-15W', 'E-cores only (efficient)', '32 EU', 'intel');
 
 -- Intel N95/N97/N100 (Alder Lake-N, 2-digit model numbers)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('N\d{2}$', 'Alder Lake-N', 'ADL-N', 2023, 1, 125, 1, 1, 1, 1, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('N\d{2}$', 'Alder Lake-N', 'ADL-N', 2023, 1, 125, 1, 1, 1, 1, 0,
+    'Intel UHD Graphics', 'Xe-LP', 'Intel 7', 0, 4, '6-15W', 'E-cores only (efficient)', '24-32 EU', 'intel');
 
 -- Gemini Lake (J4xxx, J5xxx - 2017-2019)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('J[456]\d{3}', 'Gemini Lake', 'GLK', 2017, 4, 72, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('J[456]\d{3}', 'Gemini Lake', 'GLK', 2017, 4, 72, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics 600', 'Gen9.5', '14nm', 4, NULL, '6-10W', 'Monolithic (Atom)', '12-18 EU', 'intel');
 
 -- Xeon E3 v6 (Kaby Lake)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Xeon.*E3-\d{4}\s*v6', 'Kaby Lake', 'KBL', 2017, 1, 70, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Xeon.*E3-\d{4}\s*v6', 'Kaby Lake', 'KBL', 2017, 1, 70, 1, 1, 0, 0, 0,
+    'Intel HD Graphics P630', 'Gen9.5', '14nm', 4, NULL, '35-73W', 'Monolithic', '24 EU', 'intel');
 
 -- Xeon E3 v5 (Skylake)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Xeon.*E3-\d{4}\s*v5', 'Skylake', 'SKL', 2015, 3, 60, 1, 0, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Xeon.*E3-\d{4}\s*v5', 'Skylake', 'SKL', 2015, 3, 60, 1, 0, 0, 0, 0,
+    'Intel HD Graphics P530', 'Gen9', '14nm', 4, NULL, '35-80W', 'Monolithic', '24 EU', 'intel');
 
 -- Xeon E3 v4 (Broadwell)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Xeon.*E3-\d{4}\s*v4', 'Broadwell', 'BDW', 2015, 2, 50, 1, 0, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Xeon.*E3-\d{4}\s*v4', 'Broadwell', 'BDW', 2015, 2, 50, 1, 0, 0, 0, 0,
+    'Intel HD Graphics P5700', 'Gen8', '14nm', 4, NULL, '35-65W', 'Monolithic', '48 EU', 'intel');
 
 -- Xeon E3 v3 (Haswell)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Xeon.*E3-\d{4}\s*v3', 'Haswell', 'HSW', 2013, 2, 40, 1, 0, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Xeon.*E3-\d{4}\s*v3', 'Haswell', 'HSW', 2013, 2, 40, 1, 0, 0, 0, 0,
+    'Intel HD Graphics P4600', 'Gen7.5', '22nm', 4, NULL, '35-84W', 'Monolithic', '20 EU', 'intel');
 
 -- Xeon E-21xx/22xx/23xx standalone (matches E-2144G, E-2288G without "Xeon" prefix)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('E-2[123]\d{2}G?', 'Xeon E', 'CFL', 2018, 4, 85, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('E-2[123]\d{2}G?', 'Xeon E', 'CFL', 2018, 4, 85, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics P630', 'Gen9.5', '14nm', 8, NULL, '35-95W', 'Monolithic', '24 EU', 'intel');
 
 -- Pentium G4xxx (Coffee Lake era)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('G4\d{3}[T]?', 'Coffee Lake', 'CFL', 2018, 4, 80, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('G4\d{3}[T]?', 'Coffee Lake', 'CFL', 2018, 4, 80, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics 610', 'Gen9.5', '14nm', 2, NULL, '35-54W', 'Monolithic', '24 EU', 'intel');
 
 -- Core m3-8100Y (Amber Lake)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('m3-\d{4}Y', 'Amber Lake', 'AML-Y', 2018, 3, 83, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('m3-\d{4}Y', 'Amber Lake', 'AML-Y', 2018, 3, 83, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics 615', 'Gen9.5', '14nm', 2, NULL, '5W', 'Monolithic (ultra-mobile)', '24 EU', 'intel');
 
 -- Core M-5Yxx (Broadwell-Y)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('M-5Y\d{2}', 'Broadwell', 'BDW-Y', 2014, 4, 50, 1, 0, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('M-5Y\d{2}', 'Broadwell', 'BDW-Y', 2014, 4, 50, 1, 0, 0, 0, 0,
+    'Intel HD Graphics 5300', 'Gen8', '14nm', 2, NULL, '4.5W', 'Monolithic (ultra-mobile)', '24 EU', 'intel');
 
 -- Pentium Silver (Gemini Lake)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Pentium.*Silver', 'Gemini Lake', 'GLK', 2017, 4, 72, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Pentium.*Silver', 'Gemini Lake', 'GLK', 2017, 4, 72, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics 605', 'Gen9.5', '14nm', 4, NULL, '6-10W', 'Monolithic (Atom)', '18 EU', 'intel');
 
 -- Silver Jxxxx/Nxxxx (Gemini Lake, standalone)
 INSERT INTO cpu_architectures (pattern, architecture, codename, release_year, release_quarter, sort_order,
-    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode, vendor) VALUES
-('Silver.*\d{4}', 'Gemini Lake', 'GLK', 2017, 4, 72, 1, 1, 0, 0, 0, 'intel');
+    h264_encode, hevc_8bit_encode, hevc_10bit_encode, vp9_encode, av1_encode,
+    igpu_name, igpu_codename, process_nm, max_p_cores, max_e_cores, tdp_range, die_layout, gpu_eu_count, vendor) VALUES
+('Silver.*\d{4}', 'Gemini Lake', 'GLK', 2017, 4, 72, 1, 1, 0, 0, 0,
+    'Intel UHD Graphics 605', 'Gen9.5', '14nm', 4, NULL, '6-10W', 'Monolithic (Atom)', '18 EU', 'intel');

--- a/web/.astro/types.d.ts
+++ b/web/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,6550 @@
+{
+  "name": "quicksync-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "quicksync-web",
+      "version": "1.0.0",
+      "dependencies": {
+        "astro": "^5.7.0",
+        "chart.js": "^4.4.0"
+      },
+      "devDependencies": {
+        "@astrojs/cloudflare": "^12.0.0",
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@astrojs/cloudflare": {
+      "version": "12.6.12",
+      "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.12.tgz",
+      "integrity": "sha512-f6iXreyJc02EhokqsoPf7D/s3tebyZ8dBNVOyY2JDY87ujft4RokVS1f+zNwNFyu0wkehC4ALUboU5z590DE4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.7.5",
+        "@astrojs/underscore-redirects": "1.0.0",
+        "@cloudflare/workers-types": "^4.20251121.0",
+        "tinyglobby": "^0.2.15",
+        "vite": "^6.4.1",
+        "wrangler": "4.50.0"
+      },
+      "peerDependencies": {
+        "astro": "^5.7.0"
+      }
+    },
+    "node_modules/@astrojs/compiler": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.0.tgz",
+      "integrity": "sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==",
+      "license": "MIT"
+    },
+    "node_modules/@astrojs/internal-helpers": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.5.tgz",
+      "integrity": "sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==",
+      "license": "MIT"
+    },
+    "node_modules/@astrojs/markdown-remark": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.9.tgz",
+      "integrity": "sha512-hX2cLC/KW74Io1zIbn92kI482j9J7LleBLGCVU9EP3BeH5MVrnFawOnqD0t/q6D1Z+ZNeQG2gNKMslCcO36wng==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.7.5",
+        "@astrojs/prism": "3.3.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "import-meta-resolve": "^4.2.0",
+        "js-yaml": "^4.1.0",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "shiki": "^3.13.0",
+        "smol-toml": "^1.4.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/prism": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+      "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/telemetry": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^4.2.0",
+        "debug": "^4.4.0",
+        "dlv": "^1.1.3",
+        "dset": "^3.1.4",
+        "is-docker": "^3.0.0",
+        "is-wsl": "^3.1.0",
+        "which-pm-runs": "^1.1.0"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/underscore-redirects": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/underscore-redirects/-/underscore-redirects-1.0.0.tgz",
+      "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@capsizecss/unpack": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-3.0.1.tgz",
+      "integrity": "sha512-8XqW8xGn++Eqqbz3e9wKuK7mxryeRjs4LOHLxbh2lwKeSbuNR4NFifDZT4KzvjU6HMOPbiNTsWpniK5EJfTWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkit": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.0.tgz",
+      "integrity": "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.7.11",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.7.11.tgz",
+      "integrity": "sha512-se23f1D4PxKrMKOq+Stz+Yn7AJ9ITHcEecXo2Yjb+UgbUDCEBch1FXQC6hx6uT5fNA3kmX3mfzeZiUmpK1W9IQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "^1.20251106.1"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20251118.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20251118.0.tgz",
+      "integrity": "sha512-UmWmYEYS/LkK/4HFKN6xf3Hk8cw70PviR+ftr3hUvs9HYZS92IseZEp16pkL6ZBETrPRpZC7OrzoYF7ky6kHsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20251118.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20251118.0.tgz",
+      "integrity": "sha512-RockU7Qzf4rxNfY1lx3j4rvwutNLjTIX7rr2hogbQ4mzLo8Ea40/oZTzXVxl+on75joLBrt0YpenGW8o/r44QA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20251118.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20251118.0.tgz",
+      "integrity": "sha512-aT97GnOAbJDuuOG0zPVhgRk0xFtB1dzBMrxMZ09eubDLoU4djH4BuORaqvxNRMmHgKfa4T6drthckT0NjUvBdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20251118.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20251118.0.tgz",
+      "integrity": "sha512-bXZPJcwlq00MPOXqP7DMWjr+goYj0+Fqyw6zgEC2M3FR1+SWla4yjghnZ4IdpN+H1t7VbUrsi5np2LzMUFs0NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20251118.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20251118.0.tgz",
+      "integrity": "sha512-2LV99AHSlpr8WcCb/BYbU2QsYkXLUL1izN6YKWkN9Eibv80JKX0RtgmD3dfmajE5sNvClavxZejgzVvHD9N9Ag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20251205.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251205.0.tgz",
+      "integrity": "sha512-7pup7fYkuQW5XD8RUS/vkxF9SXlrGyCXuZ4ro3uVQvca/GTeSa+8bZ8T4wbq1Aea5lmLIGSlKbhl2msME7bRBA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
+      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.5.tgz",
+      "integrity": "sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/colors/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.2.tgz",
+      "integrity": "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
+      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
+      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
+      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
+      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
+      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
+      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
+      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
+      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
+      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
+      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
+      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
+      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
+      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
+      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
+      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
+      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
+      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
+      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
+      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
+      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.19.0.tgz",
+      "integrity": "sha512-L7SrRibU7ZoYi1/TrZsJOFAnnHyLTE1SwHG1yNWjZIVCqjOEmCSuK2ZO9thnRbJG6TOkPp+Z963JmpCNw5nzvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.19.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.19.0.tgz",
+      "integrity": "sha512-ZfWJNm2VMhKkQIKT9qXbs76RRcT0SF/CAvEz0+RkpUDAoDaCx0uFdCGzSRiD9gSlhm6AHkjdieOBJMaO2eC1rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.19.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.19.0.tgz",
+      "integrity": "sha512-1hRxtYIJfJSZeM5ivbUXv9hcJP3PWRo5prG/V2sWwiubUKTa+7P62d2qxCW8jiVFX4pgRHhnHNp+qeR7Xl+6kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.19.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.19.0.tgz",
+      "integrity": "sha512-dBMFzzg1QiXqCVQ5ONc0z2ebyoi5BKz+MtfByLm0o5/nbUu3Iz8uaTCa5uzGiscQKm7lVShfZHU1+OG3t5hgwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.19.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.19.0.tgz",
+      "integrity": "sha512-H36qw+oh91Y0s6OlFfdSuQ0Ld+5CgB/VE6gNPK+Hk4VRbVG/XQgkjnt4KzfnnoO6tZPtKJKHPjwebOCfjd6F8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.19.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.19.0.tgz",
+      "integrity": "sha512-Z2hdeEQlzuntf/BZpFG8a+Fsw9UVXdML7w0o3TgSXV3yNESGon+bs9ITkQb3Ki7zxoXOOu5oJWqZ2uto06V9iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.1.1.tgz",
+      "integrity": "sha512-rO92VvpgMc3kfiTjGT52LEtJ8Yc5kCWhZjLQ3LwlA4pSgPpQO7bVpYXParOD8Jwf+cVQECJo3yP/4I8aZtUQTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.12.tgz",
+      "integrity": "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/fontkit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/fontkit/-/fontkit-2.0.8.tgz",
+      "integrity": "sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/nlcst": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-iterate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+      "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/astro": {
+      "version": "5.16.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.4.tgz",
+      "integrity": "sha512-rgXI/8/tnO3Y9tfAaUyg/8beKhlIMltbiC8Q6jCoAfEidOyaue4KYKzbe0gJIb6qEdEaG3Kf3BY3EOSLkbWOLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.0",
+        "@astrojs/internal-helpers": "0.7.5",
+        "@astrojs/markdown-remark": "6.3.9",
+        "@astrojs/telemetry": "3.3.0",
+        "@capsizecss/unpack": "^3.0.1",
+        "@oslojs/encoding": "^1.1.0",
+        "@rollup/pluginutils": "^5.3.0",
+        "acorn": "^8.15.0",
+        "aria-query": "^5.3.2",
+        "axobject-query": "^4.1.0",
+        "boxen": "8.0.1",
+        "ci-info": "^4.3.1",
+        "clsx": "^2.1.1",
+        "common-ancestor-path": "^1.0.1",
+        "cookie": "^1.0.2",
+        "cssesc": "^3.0.0",
+        "debug": "^4.4.3",
+        "deterministic-object-hash": "^2.0.2",
+        "devalue": "^5.5.0",
+        "diff": "^5.2.0",
+        "dlv": "^1.1.3",
+        "dset": "^3.1.4",
+        "es-module-lexer": "^1.7.0",
+        "esbuild": "^0.25.0",
+        "estree-walker": "^3.0.3",
+        "flattie": "^1.1.1",
+        "fontace": "~0.3.1",
+        "github-slugger": "^2.0.0",
+        "html-escaper": "3.0.3",
+        "http-cache-semantics": "^4.2.0",
+        "import-meta-resolve": "^4.2.0",
+        "js-yaml": "^4.1.1",
+        "magic-string": "^0.30.21",
+        "magicast": "^0.5.1",
+        "mrmime": "^2.0.1",
+        "neotraverse": "^0.6.18",
+        "p-limit": "^6.2.0",
+        "p-queue": "^8.1.1",
+        "package-manager-detector": "^1.5.0",
+        "piccolore": "^0.1.3",
+        "picomatch": "^4.0.3",
+        "prompts": "^2.4.2",
+        "rehype": "^13.0.2",
+        "semver": "^7.7.3",
+        "shiki": "^3.15.0",
+        "smol-toml": "^1.5.2",
+        "svgo": "^4.0.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tsconfck": "^3.1.6",
+        "ultrahtml": "^1.6.0",
+        "unifont": "~0.6.0",
+        "unist-util-visit": "^5.0.0",
+        "unstorage": "^1.17.3",
+        "vfile": "^6.0.3",
+        "vite": "^6.4.1",
+        "vitefu": "^1.1.1",
+        "xxhash-wasm": "^1.1.0",
+        "yargs-parser": "^21.1.1",
+        "yocto-spinner": "^0.2.3",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.25.0",
+        "zod-to-ts": "^1.2.0"
+      },
+      "bin": {
+        "astro": "astro.js"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/astrodotbuild"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+      "license": "ISC"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
+      "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
+      "license": "MIT"
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/deterministic-object-hash": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+      "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-64": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.5.0.tgz",
+      "integrity": "sha512-69sM5yrHfFLJt0AZ9QqZXGCPfJ7fQjvpln3Rq5+PS03LD32Ost1Q9N+eEnaQwGRIriKkMImXD56ocjQmfjbV3w==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "license": "MIT"
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/flattie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fontace": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.3.1.tgz",
+      "integrity": "sha512-9f5g4feWT1jWT8+SbL85aLIRLIXUaDygaM2xPXRmzPYxrOMNok79Lr3FGJoKVNKibE0WCunNiEVG2mwuE+2qEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/fontkit": "^2.0.8",
+        "fontkit": "^2.0.4"
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/h3": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.4.tgz",
+      "integrity": "sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.2",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.4",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.2",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.1",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-definitions": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20251118.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20251118.1.tgz",
+      "integrity": "sha512-uLSAE/DvOm392fiaig4LOaatxLjM7xzIniFRG5Y3yF9IduOYLLK/pkCPQNCgKQH3ou0YJRHnTN+09LPfqYNTQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "sharp": "^0.33.5",
+        "stoppable": "1.1.0",
+        "undici": "7.14.0",
+        "workerd": "1.20251118.0",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/miniflare/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neotraverse": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/nlcst-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
+      "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+      "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-latin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+      "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "@types/unist": "^3.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-modify-children": "^4.0.0",
+        "unist-util-visit-children": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
+      "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/rehype": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "rehype-parse": "^9.0.0",
+        "rehype-stringify": "^10.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-smartypants": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
+      "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
+      "license": "MIT",
+      "dependencies": {
+        "retext": "^9.0.0",
+        "retext-smartypants": "^6.0.0",
+        "unified": "^11.0.4",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
+    "node_modules/retext": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+      "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "retext-latin": "^4.0.0",
+        "retext-stringify": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-latin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+      "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "parse-latin": "^7.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-smartypants": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/retext-stringify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+      "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
+      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.53.3",
+        "@rollup/rollup-android-arm64": "4.53.3",
+        "@rollup/rollup-darwin-arm64": "4.53.3",
+        "@rollup/rollup-darwin-x64": "4.53.3",
+        "@rollup/rollup-freebsd-arm64": "4.53.3",
+        "@rollup/rollup-freebsd-x64": "4.53.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
+        "@rollup/rollup-linux-arm64-musl": "4.53.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-musl": "4.53.3",
+        "@rollup/rollup-openharmony-arm64": "4.53.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
+        "@rollup/rollup-win32-x64-gnu": "4.53.3",
+        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.19.0.tgz",
+      "integrity": "sha512-77VJr3OR/VUZzPiStyRhADmO2jApMM0V2b1qf0RpfWya8Zr1PeZev5AEpPGAAKWdiYUtcZGBE4F5QvJml1PvWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.19.0",
+        "@shikijs/engine-javascript": "3.19.0",
+        "@shikijs/engine-oniguruma": "3.19.0",
+        "@shikijs/langs": "3.19.0",
+        "@shikijs/themes": "3.19.0",
+        "@shikijs/types": "3.19.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
+      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
+      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "license": "MIT"
+    },
+    "node_modules/ultrahtml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
+      "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==",
+      "license": "MIT"
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unifont": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.6.0.tgz",
+      "integrity": "sha512-5Fx50fFQMQL5aeHyWnZX9122sSLckcDvcfFiBf3QYeHa7a1MKJooUy52b67moi2MJYkrfo/TWY+CoLdr/w0tTA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0",
+        "ofetch": "^1.4.1",
+        "ohash": "^2.0.0"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-modify-children": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+      "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "array-iterate": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-children": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+      "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.3.tgz",
+      "integrity": "sha512-i+JYyy0DoKmQ3FximTHbGadmIYb8JEpq7lxUjnjeB702bCPum0vzo6oy5Mfu0lpqISw7hCyMW2yj4nWC8bqJ3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^4.0.3",
+        "destr": "^2.0.5",
+        "h3": "^1.15.4",
+        "lru-cache": "^10.4.3",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.1"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6.0.3 || ^7.0.0",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1.0.1",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz",
+      "integrity": "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/which-pm-runs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20251118.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251118.0.tgz",
+      "integrity": "sha512-Om5ns0Lyx/LKtYI04IV0bjIrkBgoFNg0p6urzr2asekJlfP18RqFzyqMFZKf0i9Gnjtz/JfAS/Ol6tjCe5JJsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20251118.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20251118.0",
+        "@cloudflare/workerd-linux-64": "1.20251118.0",
+        "@cloudflare/workerd-linux-arm64": "1.20251118.0",
+        "@cloudflare/workerd-windows-64": "1.20251118.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.50.0.tgz",
+      "integrity": "sha512-+nuZuHZxDdKmAyXOSrHlciGshCoAPiy5dM+t6mEohWm7HpXvTHmWQGUf/na9jjWlWJHCJYOWzkA1P5HBJqrIEA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.0",
+        "@cloudflare/unenv-preset": "2.7.11",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.25.4",
+        "miniflare": "4.20251118.1",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20251118.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20251118.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
+      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
+      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
+      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
+      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
+      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
+      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
+      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
+      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
+      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
+      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
+      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
+      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
+      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
+      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
+      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
+      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
+      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
+      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
+      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
+      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
+      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
+      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
+      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.4",
+        "@esbuild/android-arm": "0.25.4",
+        "@esbuild/android-arm64": "0.25.4",
+        "@esbuild/android-x64": "0.25.4",
+        "@esbuild/darwin-arm64": "0.25.4",
+        "@esbuild/darwin-x64": "0.25.4",
+        "@esbuild/freebsd-arm64": "0.25.4",
+        "@esbuild/freebsd-x64": "0.25.4",
+        "@esbuild/linux-arm": "0.25.4",
+        "@esbuild/linux-arm64": "0.25.4",
+        "@esbuild/linux-ia32": "0.25.4",
+        "@esbuild/linux-loong64": "0.25.4",
+        "@esbuild/linux-mips64el": "0.25.4",
+        "@esbuild/linux-ppc64": "0.25.4",
+        "@esbuild/linux-riscv64": "0.25.4",
+        "@esbuild/linux-s390x": "0.25.4",
+        "@esbuild/linux-x64": "0.25.4",
+        "@esbuild/netbsd-arm64": "0.25.4",
+        "@esbuild/netbsd-x64": "0.25.4",
+        "@esbuild/openbsd-arm64": "0.25.4",
+        "@esbuild/openbsd-x64": "0.25.4",
+        "@esbuild/sunos-x64": "0.25.4",
+        "@esbuild/win32-arm64": "0.25.4",
+        "@esbuild/win32-ia32": "0.25.4",
+        "@esbuild/win32-x64": "0.25.4"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yocto-spinner": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+      "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.19"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
+      "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/zod-to-ts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+      "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+      "peerDependencies": {
+        "typescript": "^4.9.4 || ^5.0.2",
+        "zod": "^3"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/web/src/components/CpuLink.astro
+++ b/web/src/components/CpuLink.astro
@@ -1,0 +1,87 @@
+---
+/**
+ * CpuLink component - renders a clickable link to the CPU's generation detail page
+ *
+ * Usage:
+ *   <CpuLink cpuRaw="Intel(R) Core(TM) i5-8500 CPU @ 3.00GHz" generation={8} />
+ *   <CpuLink cpuRaw="Intel Arc A770" architecture="Arc Alchemist" />
+ */
+
+interface Props {
+  cpuRaw: string;
+  generation?: number | null;
+  architecture?: string | null;
+  showFullName?: boolean;
+}
+
+const { cpuRaw, generation, architecture, showFullName = false } = Astro.props;
+
+// Strip Intel branding for cleaner display
+function stripIntelBranding(cpu: string): string {
+  return cpu
+    .replace(/Intel\(R\)\s*/gi, '')
+    .replace(/Core\(TM\)\s*/gi, '')
+    .replace(/CPU\s*@\s*[\d.]+GHz/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Determine the link URL based on architecture/generation
+function getCpuLink(): string | null {
+  // Arc GPUs go to their own page
+  if (architecture?.includes('Arc')) {
+    if (architecture === 'Arc Alchemist') {
+      return '/gpu/arc/alchemist';
+    }
+    if (architecture === 'Arc Battlemage') {
+      return '/gpu/arc/battlemage';
+    }
+    return '/gpu/arc/all';
+  }
+
+  // Ultra Series (Meteor Lake, Arrow Lake, Lunar Lake)
+  if (architecture === 'Meteor Lake') {
+    return '/cpu/gen/ultra-1';
+  }
+  if (architecture === 'Arrow Lake' || architecture === 'Lunar Lake') {
+    return '/cpu/gen/ultra-2';
+  }
+
+  // Standard generations (2-14)
+  if (generation && generation >= 2 && generation <= 14) {
+    return `/cpu/gen/${generation}`;
+  }
+
+  return null;
+}
+
+const displayName = showFullName ? cpuRaw : stripIntelBranding(cpuRaw);
+const href = getCpuLink();
+---
+
+{href ? (
+  <a href={href} class="cpu-link" title={cpuRaw}>
+    {displayName}
+  </a>
+) : (
+  <span class="cpu-name" title={cpuRaw}>
+    {displayName}
+  </span>
+)}
+
+<style>
+  .cpu-link {
+    color: var(--color-accent);
+    text-decoration: none;
+    transition: color 0.15s ease;
+  }
+
+  .cpu-link:hover {
+    color: var(--color-accent-hover, #60a5fa);
+    text-decoration: underline;
+  }
+
+  .cpu-name {
+    color: var(--color-text);
+  }
+</style>

--- a/web/src/components/generation/ArchitectureCard.astro
+++ b/web/src/components/generation/ArchitectureCard.astro
@@ -1,0 +1,321 @@
+---
+/**
+ * ArchitectureCard - Shows iGPU name, EU count, die layout, process node
+ * Supports multiple architecture variants (e.g., 12th-14th gen have different dies)
+ */
+
+interface ArchVariant {
+  name: string | null;
+  codename: string | null;
+  pattern: string | null;
+  release_year: number | null;
+  igpu_name: string | null;
+  igpu_codename: string | null;
+  process_nm: string | null;
+  max_p_cores: number | null;
+  max_e_cores: number | null;
+  tdp_range: string | null;
+  die_layout: string | null;
+  gpu_eu_count: string | null;
+}
+
+interface CpuModel {
+  cpu_raw: string;
+  result_count: number;
+  avg_fps: number;
+  fps_per_watt: number | null;
+  score: number | null;
+}
+
+interface Props {
+  architecture: ArchVariant;
+  variants?: ArchVariant[];
+  hasMultipleVariants?: boolean;
+  cpuModels?: CpuModel[];
+}
+
+const { architecture, variants, hasMultipleVariants, cpuModels } = Astro.props;
+
+// If we have multiple variants, show them all
+const displayVariants = hasMultipleVariants && variants && variants.length > 1 ? variants : [architecture];
+
+// Build specs for a single variant
+function buildSpecs(arch: ArchVariant) {
+  return [
+    { label: 'iGPU', value: arch.igpu_name, sublabel: arch.igpu_codename },
+    { label: 'EU Count', value: arch.gpu_eu_count },
+    { label: 'Process', value: arch.process_nm },
+    { label: 'Max P-Cores', value: arch.max_p_cores?.toString() },
+    { label: 'Max E-Cores', value: arch.max_e_cores !== null ? arch.max_e_cores.toString() : null },
+    { label: 'TDP Range', value: arch.tdp_range },
+    { label: 'Die Layout', value: arch.die_layout },
+  ].filter(spec => spec.value);
+}
+
+// Match CPUs to variants based on pattern
+function getCpusForVariant(variant: ArchVariant, allCpus: CpuModel[]): CpuModel[] {
+  if (!variant.pattern || !allCpus || allCpus.length === 0) return [];
+
+  try {
+    const regex = new RegExp(variant.pattern, 'i');
+    return allCpus.filter(cpu => regex.test(cpu.cpu_raw));
+  } catch {
+    return [];
+  }
+}
+
+// Strip Intel branding for cleaner display
+function stripCpuBranding(cpu: string): string {
+  return cpu
+    .replace(/Intel\(R\)\s*/gi, '')
+    .replace(/Core\(TM\)\s*/gi, '')
+    .replace(/\s+CPU\s*@\s*[\d.]+GHz/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+---
+
+<div class="architecture-card">
+  {displayVariants.length > 1 ? (
+    <>
+      <div class="multi-variant-header">
+        <h3 class="arch-name">{architecture.name || 'Unknown'}</h3>
+        <span class="variant-badge">{displayVariants.length} die variants</span>
+      </div>
+      <p class="variant-intro">
+        This generation uses different silicon depending on CPU model. Lower-tier chips (i3, i5 non-K) use a different die than higher-tier chips (i5-K, i7, i9).
+      </p>
+      <div class="variants-container">
+        {displayVariants.map((variant) => {
+          const variantCpus = getCpusForVariant(variant, cpuModels || []);
+          return (
+            <div class="variant-card">
+              <div class="variant-header">
+                <span class="variant-codename">{variant.codename}</span>
+                {variant.release_year && <span class="variant-year">{variant.release_year}</span>}
+                {variantCpus.length > 0 && (
+                  <span class="variant-cpu-count">{variantCpus.length} CPU{variantCpus.length !== 1 ? 's' : ''} tested</span>
+                )}
+              </div>
+              <div class="specs-grid">
+                {buildSpecs(variant).map(spec => (
+                  <div class="spec-item">
+                    <span class="spec-label">{spec.label}</span>
+                    <span class="spec-value">{spec.value}</span>
+                    {spec.sublabel && (
+                      <span class="spec-sublabel">{spec.sublabel}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+              {variantCpus.length > 0 && (
+                <div class="variant-cpus">
+                  <span class="variant-cpus-label">Tested CPUs using this die:</span>
+                  <div class="variant-cpus-list">
+                    {variantCpus.map(cpu => (
+                      <span class="variant-cpu-chip">{stripCpuBranding(cpu.cpu_raw)}</span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </>
+  ) : (
+    <>
+      <div class="card-header">
+        <h3 class="arch-name">{architecture.name || 'Unknown'}</h3>
+        {architecture.codename && (
+          <span class="arch-codename">{architecture.codename}</span>
+        )}
+        {architecture.release_year && (
+          <span class="arch-year">{architecture.release_year}</span>
+        )}
+      </div>
+
+      <div class="specs-grid">
+        {buildSpecs(architecture).map(spec => (
+          <div class="spec-item">
+            <span class="spec-label">{spec.label}</span>
+            <span class="spec-value">{spec.value}</span>
+            {spec.sublabel && (
+              <span class="spec-sublabel">{spec.sublabel}</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </>
+  )}
+</div>
+
+<style>
+  .architecture-card {
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+  }
+
+  .card-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .multi-variant-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .variant-badge {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.25rem 0.5rem;
+    background: rgba(245, 158, 11, 0.15);
+    color: #f59e0b;
+    border-radius: 0.25rem;
+  }
+
+  .variant-intro {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    margin-bottom: 1rem;
+    line-height: 1.5;
+  }
+
+  .variants-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .variant-card {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    padding: 1rem;
+  }
+
+  .variant-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .variant-codename {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-accent);
+    background: rgba(59, 130, 246, 0.1);
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+  }
+
+  .variant-year {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+
+  .variant-cpu-count {
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+    margin-left: auto;
+  }
+
+  .variant-cpus {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .variant-cpus-label {
+    display: block;
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    margin-bottom: 0.5rem;
+  }
+
+  .variant-cpus-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+
+  .variant-cpu-chip {
+    display: inline-block;
+    font-size: 0.75rem;
+    padding: 0.1875rem 0.5rem;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: 0.25rem;
+    color: var(--color-text);
+  }
+
+  .arch-name {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0;
+  }
+
+  .arch-codename {
+    font-size: 0.875rem;
+    color: var(--color-accent);
+    font-weight: 500;
+    background: rgba(59, 130, 246, 0.1);
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+  }
+
+  .arch-year {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  .specs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .spec-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .spec-label {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+  }
+
+  .spec-value {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+
+  .spec-sublabel {
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+  }
+
+  @media (max-width: 480px) {
+    .specs-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+</style>

--- a/web/src/components/generation/CodecMatrix.astro
+++ b/web/src/components/generation/CodecMatrix.astro
@@ -1,0 +1,129 @@
+---
+/**
+ * CodecMatrix - Visual codec support table with checkmarks/crosses
+ */
+
+interface Props {
+  codecSupport: {
+    h264_encode: boolean;
+    hevc_8bit_encode: boolean;
+    hevc_10bit_encode: boolean;
+    vp9_encode: boolean;
+    av1_encode: boolean;
+  };
+  compact?: boolean;
+}
+
+const { codecSupport, compact = false } = Astro.props;
+
+const codecs = [
+  { key: 'h264_encode', name: 'H.264', description: 'Most compatible, widely supported' },
+  { key: 'hevc_8bit_encode', name: 'HEVC 8-bit', description: 'Better compression than H.264' },
+  { key: 'hevc_10bit_encode', name: 'HEVC 10-bit', description: 'HDR support, better gradients' },
+  { key: 'vp9_encode', name: 'VP9', description: 'YouTube/web streaming codec' },
+  { key: 'av1_encode', name: 'AV1', description: 'Next-gen, best compression' },
+] as const;
+---
+
+<div class:list={['codec-matrix', { compact }]}>
+  <table>
+    <thead>
+      <tr>
+        <th>Codec</th>
+        <th>Encode</th>
+        {!compact && <th>Notes</th>}
+      </tr>
+    </thead>
+    <tbody>
+      {codecs.map(codec => {
+        const supported = codecSupport[codec.key as keyof typeof codecSupport];
+        return (
+          <tr class:list={{ supported, unsupported: !supported }}>
+            <td class="codec-name">{codec.name}</td>
+            <td class="codec-status">
+              {supported ? (
+                <span class="status-yes" title="Hardware encode supported">&#10003;</span>
+              ) : (
+                <span class="status-no" title="Not supported">&#10005;</span>
+              )}
+            </td>
+            {!compact && (
+              <td class="codec-description">{codec.description}</td>
+            )}
+          </tr>
+        );
+      })}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .codec-matrix {
+    width: 100%;
+  }
+
+  .codec-matrix table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .codec-matrix th {
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    font-weight: 500;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .codec-matrix td {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 0.875rem;
+  }
+
+  .codec-name {
+    font-weight: 500;
+  }
+
+  .codec-status {
+    text-align: center;
+    width: 4rem;
+  }
+
+  .status-yes {
+    color: #22c55e;
+    font-weight: 700;
+    font-size: 1.25rem;
+  }
+
+  .status-no {
+    color: #6b7280;
+    font-size: 1rem;
+  }
+
+  .codec-description {
+    color: var(--color-text-muted);
+    font-size: 0.8125rem;
+  }
+
+  tr.supported .codec-name {
+    color: var(--color-text);
+  }
+
+  tr.unsupported .codec-name {
+    color: var(--color-text-muted);
+  }
+
+  /* Compact mode */
+  .codec-matrix.compact th,
+  .codec-matrix.compact td {
+    padding: 0.375rem 0.5rem;
+  }
+
+  .codec-matrix.compact .codec-name {
+    font-size: 0.8125rem;
+  }
+</style>

--- a/web/src/components/generation/CpuModelTable.astro
+++ b/web/src/components/generation/CpuModelTable.astro
@@ -1,0 +1,179 @@
+---
+/**
+ * CpuModelTable - Table of CPUs in a generation with benchmark data
+ */
+
+interface CpuModel {
+  cpu_raw: string;
+  result_count: number;
+  avg_fps: number;
+  fps_per_watt: number | null;
+  score: number | null;
+}
+
+// Get score badge class based on score value
+function getScoreClass(score: number | null): string {
+  if (score === null) return '';
+  if (score >= 70) return 'score-high';
+  if (score >= 40) return 'score-mid';
+  return 'score-low';
+}
+
+interface Props {
+  cpuModels: CpuModel[];
+  generationId: string;
+}
+
+const { cpuModels, generationId } = Astro.props;
+
+// Strip Intel branding for cleaner display
+function stripIntelBranding(cpu: string): string {
+  return cpu
+    .replace(/Intel\(R\)\s*/gi, '')
+    .replace(/Core\(TM\)\s*/gi, '')
+    .replace(/CPU\s*@\s*[\d.]+GHz/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+---
+
+<div class="cpu-model-table">
+  <table>
+    <thead>
+      <tr>
+        <th>CPU Model</th>
+        <th class="numeric">Results</th>
+        <th class="numeric">Avg FPS</th>
+        <th class="numeric">FPS/Watt</th>
+        <th class="numeric">Score</th>
+      </tr>
+    </thead>
+    <tbody>
+      {cpuModels.length === 0 ? (
+        <tr>
+          <td colspan="5" class="empty-state">
+            No benchmark data available yet for this generation.
+          </td>
+        </tr>
+      ) : (
+        cpuModels.map((cpu, index) => (
+          <tr>
+            <td class="cpu-name" title={cpu.cpu_raw}>
+              {index === 0 && <span class="rank-badge">Top</span>}
+              {stripIntelBranding(cpu.cpu_raw)}
+            </td>
+            <td class="numeric">{cpu.result_count}</td>
+            <td class="numeric">{cpu.avg_fps.toFixed(1)}</td>
+            <td class="numeric">
+              {cpu.fps_per_watt ? cpu.fps_per_watt.toFixed(2) : '—'}
+            </td>
+            <td class="numeric">
+              {cpu.score !== null ? (
+                <span class:list={['score-badge', getScoreClass(cpu.score)]}>{cpu.score}</span>
+              ) : '—'}
+            </td>
+          </tr>
+        ))
+      )}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .cpu-model-table {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .cpu-model-table table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+
+  .cpu-model-table th {
+    text-align: left;
+    padding: 0.75rem 1rem;
+    font-weight: 500;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    border-bottom: 2px solid var(--color-border);
+  }
+
+  .cpu-model-table th.numeric {
+    text-align: right;
+  }
+
+  .cpu-model-table td {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--color-border);
+    vertical-align: middle;
+  }
+
+  .cpu-model-table td.numeric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .cpu-model-table tbody tr:hover {
+    background-color: rgba(59, 130, 246, 0.05);
+  }
+
+  .cpu-name {
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 500;
+  }
+
+  .rank-badge {
+    display: inline-block;
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    padding: 0.125rem 0.375rem;
+    margin-right: 0.5rem;
+    background: linear-gradient(135deg, #ffd700, #ffb700);
+    color: #1a1a1a;
+    border-radius: 0.25rem;
+  }
+
+  .empty-state {
+    text-align: center;
+    color: var(--color-text-muted);
+    padding: 2rem !important;
+    font-style: italic;
+  }
+
+  /* Score Badge */
+  .score-badge {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+  }
+
+  .score-badge.score-high {
+    background: rgba(34, 197, 94, 0.15);
+    border-color: rgba(34, 197, 94, 0.4);
+    color: #22c55e;
+  }
+
+  .score-badge.score-mid {
+    background: rgba(234, 179, 8, 0.15);
+    border-color: rgba(234, 179, 8, 0.4);
+    color: #eab308;
+  }
+
+  .score-badge.score-low {
+    background: rgba(239, 68, 68, 0.15);
+    border-color: rgba(239, 68, 68, 0.4);
+    color: #ef4444;
+  }
+</style>

--- a/web/src/components/generation/TimelineSlider.astro
+++ b/web/src/components/generation/TimelineSlider.astro
@@ -1,0 +1,200 @@
+---
+/**
+ * TimelineSlider - Visual timeline showing all CPU generations with current highlighted
+ */
+
+interface TimelineEntry {
+  identifier: string;
+  name: string;
+  codename: string;
+  release_year: number;
+}
+
+interface Props {
+  generations: TimelineEntry[];
+  currentIdentifier: string;
+}
+
+const { generations, currentIdentifier } = Astro.props;
+---
+
+<nav class="timeline-slider" aria-label="CPU Generation Timeline">
+  <div class="timeline-track">
+    {generations.map((gen, index) => {
+      const isCurrent = gen.identifier === currentIdentifier;
+      const isNumeric = !isNaN(Number(gen.identifier));
+      const isArc = gen.identifier === 'arc';
+      const prevGen = index > 0 ? generations[index - 1] : null;
+      const showArcSeparator = isArc && prevGen && prevGen.identifier !== 'arc';
+
+      // Format label based on identifier type
+      let label: string;
+      if (isNumeric) {
+        label = gen.identifier;
+      } else if (gen.identifier.startsWith('ultra-')) {
+        label = gen.identifier.replace('ultra-', 'U');
+      } else if (gen.identifier === 'arc') {
+        label = 'Arc';
+      } else {
+        label = gen.identifier;
+      }
+
+      return (
+        <>
+          {showArcSeparator && (
+            <span class="timeline-separator">
+              <span class="separator-label">dGPU</span>
+            </span>
+          )}
+          <a
+            href={`/cpu/gen/${gen.identifier}`}
+            class:list={['timeline-item', { current: isCurrent, arc: isArc }]}
+            title={`${gen.name} (${gen.release_year})`}
+            aria-current={isCurrent ? 'page' : undefined}
+          >
+            <span class="timeline-label">{label}</span>
+            {isCurrent && <span class="timeline-marker" />}
+          </a>
+        </>
+      );
+    })}
+  </div>
+  <div class="timeline-legend">
+    <span class="legend-start">Older CPUs</span>
+    <span class="legend-end">Newer / dGPUs</span>
+  </div>
+</nav>
+
+<style>
+  .timeline-slider {
+    width: 100%;
+    padding: 1rem 0;
+  }
+
+  .timeline-track {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+    position: relative;
+  }
+
+  .timeline-track::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 2rem;
+    right: 2rem;
+    height: 2px;
+    background: var(--color-border);
+    z-index: 0;
+  }
+
+  .timeline-item {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.5rem;
+    text-decoration: none;
+    color: var(--color-text-muted);
+    transition: all 0.2s ease;
+    min-width: 2.5rem;
+  }
+
+  .timeline-item:hover {
+    color: var(--color-text);
+  }
+
+  .timeline-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.25rem 0.5rem;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: 0.25rem;
+    transition: all 0.2s ease;
+  }
+
+  .timeline-item:hover .timeline-label {
+    border-color: var(--color-accent);
+  }
+
+  .timeline-item.current .timeline-label {
+    background: var(--color-accent);
+    color: white;
+    border-color: var(--color-accent);
+    font-weight: 600;
+  }
+
+  /* Arc GPU styling */
+  .timeline-item.arc .timeline-label {
+    background: linear-gradient(135deg, #1e3a5f 0%, #2d5a87 100%);
+    border-color: #3b82f6;
+  }
+
+  .timeline-item.arc:hover .timeline-label {
+    border-color: #60a5fa;
+  }
+
+  .timeline-item.arc.current .timeline-label {
+    background: linear-gradient(135deg, #3b82f6 0%, #60a5fa 100%);
+  }
+
+  /* Separator between CPU and GPU */
+  .timeline-separator {
+    display: flex;
+    align-items: center;
+    margin: 0 0.5rem;
+    position: relative;
+    z-index: 1;
+  }
+
+  .separator-label {
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    padding: 0.125rem 0.375rem;
+    background: var(--color-bg);
+    border: 1px dashed var(--color-border);
+    border-radius: 0.25rem;
+  }
+
+  .timeline-marker {
+    position: absolute;
+    bottom: -0.5rem;
+    width: 0;
+    height: 0;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    border-top: 6px solid var(--color-accent);
+  }
+
+  .timeline-legend {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.5rem 1rem 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+
+  @media (max-width: 768px) {
+    .timeline-track {
+      gap: 0.125rem;
+    }
+
+    .timeline-label {
+      font-size: 0.75rem;
+      padding: 0.125rem 0.25rem;
+    }
+
+    .timeline-item {
+      min-width: 2rem;
+      padding: 0.25rem;
+    }
+  }
+</style>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -25,6 +25,7 @@ const { title } = Astro.props;
       :root {
         --color-bg: #0f172a;
         --color-bg-secondary: #1e293b;
+        --color-bg-card: #1e293b;
         --color-text: #f1f5f9;
         --color-text-muted: #94a3b8;
         --color-accent: #3b82f6;
@@ -100,6 +101,7 @@ const { title } = Astro.props;
         </a>
         <nav style="display: flex; gap: 1.5rem;">
           <a href="/">Dashboard</a>
+          <a href="/cpu/gen/8">CPU Generations</a>
           <a href="/leaderboard">Leaderboard</a>
           <a href="/about">About</a>
           <a href="https://github.com/ironicbadger/quicksync_calc" target="_blank" rel="noopener">GitHub</a>

--- a/web/src/pages/cpu/gen/[gen].astro
+++ b/web/src/pages/cpu/gen/[gen].astro
@@ -1,0 +1,884 @@
+---
+/**
+ * CPU Generation Detail Page
+ * Dynamic route: /cpu/gen/8, /cpu/gen/12, /cpu/gen/ultra-1, etc.
+ */
+export const prerender = false;
+
+import Layout from '../../../layouts/Layout.astro';
+import TimelineSlider from '../../../components/generation/TimelineSlider.astro';
+import CodecMatrix from '../../../components/generation/CodecMatrix.astro';
+import ArchitectureCard from '../../../components/generation/ArchitectureCard.astro';
+import CpuModelTable from '../../../components/generation/CpuModelTable.astro';
+
+// Get the generation parameter from the URL
+const { gen } = Astro.params;
+
+// API base URL - use environment variable or default
+const API_BASE = import.meta.env.PUBLIC_API_URL || 'https://quicksync-api.ktz.me';
+
+// Fetch generation detail data and scores in parallel
+let generationData: any = null;
+let scoresData: Record<string, number> = {};
+let error: string | null = null;
+
+try {
+  const [genResponse, scoresResponse] = await Promise.all([
+    fetch(`${API_BASE}/api/results/generation-detail?generation=${gen}`),
+    fetch(`${API_BASE}/api/scores/for-results`),
+  ]);
+
+  if (genResponse.ok) {
+    generationData = await genResponse.json();
+    if (!generationData.success) {
+      error = generationData.error || 'Failed to load generation data';
+    }
+  } else {
+    error = `API error: ${genResponse.status}`;
+  }
+
+  if (scoresResponse.ok) {
+    const scoresJson = await scoresResponse.json();
+    if (scoresJson.success) {
+      scoresData = scoresJson.scores;
+    }
+  }
+} catch (e) {
+  error = 'Failed to connect to API';
+}
+
+// Add scores to cpu_models data and sort by score (highest first)
+if (generationData?.cpu_models) {
+  generationData.cpu_models = generationData.cpu_models
+    .map((cpu: any) => ({
+      ...cpu,
+      score: scoresData[cpu.cpu_raw] ?? null,
+    }))
+    .sort((a: any, b: any) => {
+      // Sort by score descending, nulls last
+      if (a.score === null && b.score === null) return 0;
+      if (a.score === null) return 1;
+      if (b.score === null) return -1;
+      return b.score - a.score;
+    });
+}
+
+// Strip Intel branding helper
+function stripCpuBranding(cpu: string): string {
+  return cpu
+    .replace(/Intel\(R\)\s*/gi, '')
+    .replace(/Core\(TM\)\s*/gi, '')
+    .replace(/\s+CPU\s*@\s*[\d.]+GHz/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Determine the top CPU and why it wins (now sorted by score)
+function getWinnerExplanation(cpuModels: any[]) {
+  if (!cpuModels || cpuModels.length < 2) return null;
+
+  const winner = cpuModels[0];
+  const second = cpuModels[1];
+
+  if (!winner || !second) return null;
+
+  const parts = [];
+
+  // Score advantage (primary metric now)
+  if (winner.score && second.score) {
+    const scoreDiff = winner.score - second.score;
+    if (scoreDiff > 0) {
+      parts.push(`+${scoreDiff} points vs ${stripCpuBranding(second.cpu_raw)}`);
+    }
+  }
+
+  // Efficiency highlight
+  if (winner.fps_per_watt) {
+    parts.push(`${winner.fps_per_watt.toFixed(1)} FPS/W efficiency`);
+  }
+
+  // Overall score label
+  if (winner.score) {
+    const scoreLabel = winner.score >= 70 ? 'excellent' : winner.score >= 50 ? 'good' : 'moderate';
+    parts.push(`${scoreLabel} overall (${winner.score}/100)`);
+  }
+
+  return parts.length > 0 ? parts.join(' • ') : null;
+}
+
+const winnerExplanation = getWinnerExplanation(generationData?.cpu_models);
+const topCpu = generationData?.cpu_models?.[0];
+
+// Generate page title
+const pageTitle = generationData?.display_name
+  ? `${generationData.display_name} - QuickSync Benchmarks`
+  : `Generation ${gen} - QuickSync Benchmarks`;
+
+// Helper to format performance difference
+function formatDiff(diff: number | null): string {
+  if (diff === null) return 'N/A';
+  const sign = diff >= 0 ? '+' : '';
+  return `${sign}${diff}%`;
+}
+
+function getDiffClass(diff: number | null): string {
+  if (diff === null) return '';
+  if (diff > 0) return 'positive';
+  if (diff < 0) return 'negative';
+  return '';
+}
+---
+
+<Layout title={pageTitle}>
+  <div class="container">
+    {error ? (
+      <div class="error-state">
+        <h1>Generation Not Found</h1>
+        <p>{error}</p>
+        <a href="/" class="back-link">&larr; Back to Dashboard</a>
+      </div>
+    ) : generationData ? (
+      <>
+        {/* Header with navigation */}
+        <div class="page-header">
+          <div class="nav-arrows">
+            {generationData.timeline.previous ? (
+              <a href={`/cpu/gen/${generationData.timeline.previous.identifier}`} class="nav-prev">
+                &larr; {generationData.timeline.previous.name}
+              </a>
+            ) : <span class="nav-placeholder" />}
+          </div>
+
+          <div class="header-center">
+            <h1>{generationData.display_name}</h1>
+            {generationData.architecture.name && (
+              <span class="arch-subtitle">{generationData.architecture.name}</span>
+            )}
+          </div>
+
+          <div class="nav-arrows">
+            {generationData.timeline.next ? (
+              <a href={`/cpu/gen/${generationData.timeline.next.identifier}`} class="nav-next">
+                {generationData.timeline.next.name} &rarr;
+              </a>
+            ) : <span class="nav-placeholder" />}
+          </div>
+        </div>
+
+        {/* Timeline */}
+        <section class="timeline-section card">
+          <h2>Generation Timeline</h2>
+          <TimelineSlider
+            generations={generationData.timeline.all_generations}
+            currentIdentifier={gen || ''}
+          />
+        </section>
+
+        {/* TL;DR Summary with Stats and Charts */}
+        <section class="tldr-section card">
+          <h2>TL;DR</h2>
+          <p class="tldr-text">
+            <strong>{generationData.display_name}</strong>
+            {generationData.architecture.name && ` (${generationData.architecture.name})`}
+            {generationData.architecture.release_year && `, released ${generationData.architecture.release_year}`}.
+            {generationData.has_multiple_variants && generationData.architecture_variants?.length > 1 ? (
+              <>
+                {' '}Features multiple iGPU variants:{' '}
+                {generationData.architecture_variants.map((v: any, i: number) => (
+                  <><strong>{v.igpu_name}</strong> ({v.gpu_eu_count}){i < generationData.architecture_variants.length - 1 ? ' or ' : ''}</>
+                ))}.
+                <span class="variant-note"> iGPU varies by CPU model (i3/i5 non-K vs i5-K/i7/i9).</span>
+              </>
+            ) : generationData.architecture.igpu_name && (
+              <> Features <strong>{generationData.architecture.igpu_name}</strong> with {generationData.architecture.gpu_eu_count || 'integrated graphics'}.</>
+            )}
+            {' '}Supports
+            {generationData.codec_support.h264_encode && ' H.264'}
+            {generationData.codec_support.hevc_8bit_encode && ', HEVC 8-bit'}
+            {generationData.codec_support.hevc_10bit_encode && ', HEVC 10-bit'}
+            {generationData.codec_support.vp9_encode && ', VP9'}
+            {generationData.codec_support.av1_encode && ', AV1'}
+            {' '}hardware encoding.
+          </p>
+
+          {/* Stats Grid with Baseline Comparison */}
+          {generationData.benchmark_stats.total_results > 0 && (
+            <div class="tldr-stats">
+              <div class="tldr-stats-grid">
+                <div class="tldr-stat-card">
+                  <div class="tldr-stat-label">Avg FPS</div>
+                  <div class="tldr-stat-value">{generationData.benchmark_stats.avg_fps?.toFixed(1) || '—'}</div>
+                  {gen !== '8' && generationData.baseline_comparison.fps_diff_percent !== null && (
+                    <div class:list={['tldr-stat-diff', getDiffClass(generationData.baseline_comparison.fps_diff_percent)]}>
+                      {formatDiff(generationData.baseline_comparison.fps_diff_percent)} vs 8th Gen
+                    </div>
+                  )}
+                </div>
+                <div class="tldr-stat-card">
+                  <div class="tldr-stat-label">Efficiency</div>
+                  <div class="tldr-stat-value">{generationData.benchmark_stats.fps_per_watt?.toFixed(2) || '—'}<span class="tldr-stat-unit"> FPS/W</span></div>
+                  {gen !== '8' && generationData.baseline_comparison.efficiency_diff_percent !== null && (
+                    <div class:list={['tldr-stat-diff', getDiffClass(generationData.baseline_comparison.efficiency_diff_percent)]}>
+                      {formatDiff(generationData.baseline_comparison.efficiency_diff_percent)} vs 8th Gen
+                    </div>
+                  )}
+                </div>
+                <div class="tldr-stat-card">
+                  <div class="tldr-stat-label">Avg Power</div>
+                  <div class="tldr-stat-value">{generationData.benchmark_stats.avg_watts?.toFixed(1) || '—'}<span class="tldr-stat-unit">W</span></div>
+                </div>
+                <div class="tldr-stat-card">
+                  <div class="tldr-stat-label">Results</div>
+                  <div class="tldr-stat-value">{generationData.benchmark_stats.total_results}</div>
+                  <div class="tldr-stat-sub">{generationData.benchmark_stats.unique_cpus} CPUs</div>
+                </div>
+              </div>
+
+              {/* Comparison Bar Charts */}
+              {generationData.benchmark_stats.by_test?.length > 0 && (
+                <div class="tldr-comparison-charts">
+                  <div class="tldr-chart-container">
+                    <canvas id="gen-fps-chart"></canvas>
+                  </div>
+                  <div class="tldr-chart-container">
+                    <canvas id="gen-watts-chart"></canvas>
+                  </div>
+                  <div class="tldr-chart-container">
+                    <canvas id="gen-efficiency-chart"></canvas>
+                  </div>
+                </div>
+              )}
+
+              {/* 8th Gen is the baseline message */}
+              {gen === '8' && (
+                <div class="tldr-baseline-note">
+                  <span class="baseline-badge">Baseline</span>
+                  8th Gen Coffee Lake is the reference baseline for all efficiency comparisons.
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+
+        {/* Architecture & Codec Grid */}
+        <div class="info-grid">
+          <section class="card">
+            <h2>Architecture</h2>
+            <ArchitectureCard
+              architecture={generationData.architecture}
+              variants={generationData.architecture_variants}
+              hasMultipleVariants={generationData.has_multiple_variants}
+              cpuModels={generationData.cpu_models}
+            />
+          </section>
+
+          <section class="card">
+            <h2>Codec Support</h2>
+            <CodecMatrix codecSupport={generationData.codec_support} />
+          </section>
+        </div>
+
+        {/* Benchmark Data */}
+        <section class="benchmark-section card">
+          <h2>
+            Benchmark Data
+            <span class="data-count">
+              {generationData.benchmark_stats.total_results} results from {generationData.benchmark_stats.unique_cpus} CPUs
+            </span>
+          </h2>
+
+          {generationData.benchmark_stats.total_results > 0 ? (
+            <>
+              {/* Stats by Test */}
+              <div class="test-stats">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Test</th>
+                      <th class="numeric">Avg FPS</th>
+                      <th class="numeric">Min</th>
+                      <th class="numeric">Max</th>
+                      <th class="numeric">FPS/Watt</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {generationData.benchmark_stats.by_test.map((test: any) => (
+                      <tr>
+                        <td>
+                          <span class:list={['test-badge', test.test_name.includes('hevc') ? 'hevc' : test.test_name.includes('cpu') ? 'cpu' : 'h264']}>
+                            {test.test_name}
+                          </span>
+                        </td>
+                        <td class="numeric">{test.avg_fps?.toFixed(1) || '—'}</td>
+                        <td class="numeric">{test.min_fps?.toFixed(1) || '—'}</td>
+                        <td class="numeric">{test.max_fps?.toFixed(1) || '—'}</td>
+                        <td class="numeric">{test.fps_per_watt?.toFixed(2) || '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          ) : (
+            <p class="no-data">No benchmark data available for this generation yet. <a href="/about">Learn how to contribute</a>.</p>
+          )}
+        </section>
+
+        {/* CPU Models in this Generation */}
+        <section class="cpu-models-section card">
+          <h2>CPUs in This Generation</h2>
+
+          {/* Winner explanation */}
+          {topCpu && winnerExplanation && (
+            <div class="winner-callout">
+              <span class="winner-badge">Top Performer</span>
+              <span class="winner-name">{stripCpuBranding(topCpu.cpu_raw)}</span>
+              <span class="winner-reason">{winnerExplanation}</span>
+            </div>
+          )}
+
+          <CpuModelTable cpuModels={generationData.cpu_models} generationId={gen || ''} />
+        </section>
+
+        {/* Pricing Links (Future) */}
+        <section class="pricing-section card">
+          <h2>Find This CPU</h2>
+          <p class="pricing-note">Search for {generationData.display_name} processors on popular marketplaces:</p>
+          <div class="pricing-links">
+            <a href={`https://www.ebay.com/sch/i.html?_nkw=intel+${gen}th+gen+cpu`} target="_blank" rel="noopener" class="pricing-link">
+              eBay
+            </a>
+            <a href={`https://www.amazon.com/s?k=intel+${gen}th+gen+processor`} target="_blank" rel="noopener" class="pricing-link">
+              Amazon
+            </a>
+            <a href={`https://www.newegg.com/p/pl?d=intel+${gen}th+gen`} target="_blank" rel="noopener" class="pricing-link">
+              Newegg
+            </a>
+          </div>
+        </section>
+      </>
+    ) : (
+      <div class="loading-state">
+        <p>Loading...</p>
+      </div>
+    )}
+  </div>
+</Layout>
+
+<style>
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1rem;
+  }
+
+  /* Page Header */
+  .page-header {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  .header-center {
+    text-align: center;
+  }
+
+  .header-center h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0;
+  }
+
+  .arch-subtitle {
+    display: block;
+    font-size: 1rem;
+    color: var(--color-text-muted);
+    margin-top: 0.25rem;
+  }
+
+  .nav-arrows {
+    display: flex;
+  }
+
+  .nav-arrows:first-child {
+    justify-content: flex-start;
+  }
+
+  .nav-arrows:last-child {
+    justify-content: flex-end;
+  }
+
+  .nav-prev, .nav-next {
+    padding: 0.5rem 1rem;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    transition: all 0.2s;
+  }
+
+  .nav-prev:hover, .nav-next:hover {
+    background: var(--color-bg);
+    border-color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  .nav-placeholder {
+    width: 120px;
+  }
+
+  /* Sections */
+  section {
+    margin-bottom: 1.5rem;
+  }
+
+  section h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .data-count {
+    font-size: 0.75rem;
+    font-weight: 400;
+    color: var(--color-text-muted);
+  }
+
+  /* TL;DR Section */
+  .tldr-section {
+    background: linear-gradient(135deg, var(--color-bg-secondary) 0%, rgba(59, 130, 246, 0.05) 100%);
+    border: 2px solid var(--color-accent);
+    box-shadow: 0 4px 24px rgba(59, 130, 246, 0.15);
+  }
+
+  .tldr-text {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: var(--color-text);
+    margin-bottom: 1.25rem;
+  }
+
+  .variant-note {
+    display: block;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    font-style: italic;
+    margin-top: 0.25rem;
+  }
+
+  .tldr-stats {
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .tldr-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+  }
+
+  @media (max-width: 768px) {
+    .tldr-stats-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  .tldr-stat-card {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 0.875rem;
+    text-align: center;
+  }
+
+  .tldr-stat-label {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    margin-bottom: 0.375rem;
+  }
+
+  .tldr-stat-value {
+    font-size: 1.375rem;
+    font-weight: 700;
+    color: var(--color-text);
+  }
+
+  .tldr-stat-unit {
+    font-size: 0.75rem;
+    font-weight: 400;
+    color: var(--color-text-muted);
+  }
+
+  .tldr-stat-diff {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    margin-top: 0.25rem;
+  }
+
+  .tldr-stat-diff.positive {
+    color: #22c55e;
+  }
+
+  .tldr-stat-diff.negative {
+    color: #ef4444;
+  }
+
+  .tldr-stat-sub {
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+    margin-top: 0.25rem;
+  }
+
+  /* Comparison Bar Charts */
+  .tldr-comparison-charts {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .tldr-chart-container {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    height: 220px;
+  }
+
+  @media (max-width: 768px) {
+    .tldr-chart-container {
+      height: 180px;
+    }
+  }
+
+  .tldr-baseline-note {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  .baseline-badge {
+    display: inline-block;
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.25rem 0.5rem;
+    background: var(--color-accent);
+    color: white;
+    border-radius: 0.25rem;
+  }
+
+  /* Info Grid */
+  .info-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+  }
+
+  @media (max-width: 768px) {
+    .info-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .page-header {
+      grid-template-columns: 1fr;
+      text-align: center;
+    }
+
+    .nav-arrows {
+      justify-content: center !important;
+    }
+
+    .nav-placeholder {
+      display: none;
+    }
+  }
+
+  /* Test Stats Table */
+  .test-stats {
+    overflow-x: auto;
+  }
+
+  .test-stats table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .test-stats th {
+    text-align: left;
+    padding: 0.75rem;
+    font-weight: 500;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    border-bottom: 2px solid var(--color-border);
+  }
+
+  .test-stats th.numeric {
+    text-align: right;
+  }
+
+  .test-stats td {
+    padding: 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 0.875rem;
+  }
+
+  .test-stats td.numeric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .test-badge {
+    display: inline-block;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    background-color: var(--color-bg);
+  }
+
+  .test-badge.h264 { color: #22c55e; }
+  .test-badge.hevc { color: #3b82f6; }
+  .test-badge.cpu { color: #f59e0b; }
+
+  .no-data {
+    color: var(--color-text-muted);
+    text-align: center;
+    padding: 2rem;
+  }
+
+  /* Pricing Links */
+  .pricing-note {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    margin-bottom: 1rem;
+  }
+
+  .pricing-links {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .pricing-link {
+    padding: 0.5rem 1rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    transition: all 0.2s;
+  }
+
+  .pricing-link:hover {
+    border-color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  /* States */
+  .error-state, .loading-state {
+    text-align: center;
+    padding: 4rem 2rem;
+  }
+
+  .error-state h1 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 0.5rem 1rem;
+    background: var(--color-accent);
+    color: white;
+    border-radius: 0.375rem;
+  }
+
+  .back-link:hover {
+    background: var(--color-accent-hover);
+    text-decoration: none;
+  }
+
+  /* Winner Callout */
+  .winner-callout {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem;
+    background: linear-gradient(135deg, rgba(255, 215, 0, 0.1) 0%, rgba(255, 183, 0, 0.05) 100%);
+    border: 1px solid rgba(255, 215, 0, 0.3);
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .winner-badge {
+    display: inline-block;
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.25rem 0.5rem;
+    background: linear-gradient(135deg, #ffd700, #ffb700);
+    color: #1a1a1a;
+    border-radius: 0.25rem;
+  }
+
+  .winner-name {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .winner-reason {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    flex: 1;
+  }
+
+  @media (max-width: 600px) {
+    .winner-callout {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+</style>
+
+{generationData?.benchmark_stats?.by_test?.length > 0 && (
+<script define:vars={{
+  displayName: generationData.display_name,
+  byTest: generationData.benchmark_stats.by_test,
+  baselineByTest: generationData.baseline_by_test || [],
+  isBaseline: gen === '8'
+}}>
+  // Generation colors
+  const genColor = { bg: 'rgba(6, 182, 212, 0.7)', border: 'rgb(6, 182, 212)' };
+  const baselineColor = { bg: 'rgba(120, 120, 130, 0.6)', border: 'rgb(120, 120, 130)' };
+
+  // Build datasets for comparison charts
+  function buildDatasets(metric) {
+    const testNames = byTest.map(t => t.test_name);
+
+    const datasets = [{
+      label: displayName,
+      data: testNames.map(testName => {
+        const test = byTest.find(t => t.test_name === testName);
+        return test?.[metric] || 0;
+      }),
+      backgroundColor: genColor.bg,
+      borderColor: genColor.border,
+      borderWidth: 1,
+    }];
+
+    // Add baseline if not viewing 8th gen
+    if (!isBaseline && baselineByTest.length > 0) {
+      datasets.push({
+        label: '8th Gen (Baseline)',
+        data: testNames.map(testName => {
+          const test = baselineByTest.find(t => t.test_name === testName);
+          return test?.[metric] || 0;
+        }),
+        backgroundColor: baselineColor.bg,
+        borderColor: baselineColor.border,
+        borderWidth: 1,
+      });
+    }
+
+    return datasets;
+  }
+
+  // Create comparison chart
+  function createChart(canvasId, title, yLabel, metric) {
+    const canvas = document.getElementById(canvasId);
+    if (!canvas) return null;
+
+    const testNames = byTest.map(t => t.test_name);
+
+    return new Chart(canvas, {
+      type: 'bar',
+      data: {
+        labels: testNames,
+        datasets: buildDatasets(metric),
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            position: 'top',
+            labels: { color: '#f1f5f9', font: { size: 11 } },
+          },
+          title: {
+            display: true,
+            text: title,
+            color: '#f1f5f9',
+            font: { size: 13, weight: '600' },
+          },
+          tooltip: {
+            callbacks: {
+              afterLabel: (context) => {
+                if (context.datasetIndex === 0 && !isBaseline && baselineByTest.length > 0) {
+                  const testName = testNames[context.dataIndex];
+                  const baselineTest = baselineByTest.find(t => t.test_name === testName);
+                  const baseVal = baselineTest?.[metric];
+                  if (baseVal && baseVal > 0) {
+                    const diff = metric === 'avg_watts'
+                      ? ((baseVal - context.raw) / baseVal * 100)
+                      : ((context.raw - baseVal) / baseVal * 100);
+                    return `${diff >= 0 ? '+' : ''}${diff.toFixed(0)}% vs 8th Gen`;
+                  }
+                }
+                return '';
+              }
+            }
+          }
+        },
+        scales: {
+          x: {
+            ticks: { color: '#94a3b8', font: { size: 10 } },
+            grid: { color: '#334155' },
+          },
+          y: {
+            ticks: { color: '#94a3b8' },
+            grid: { color: '#334155' },
+            title: { display: true, text: yLabel, color: '#94a3b8' },
+          },
+        },
+      },
+    });
+  }
+
+  // Load Chart.js and create charts
+  function initCharts() {
+    createChart('gen-fps-chart', 'Average FPS by Test Type', 'Frames per Second', 'avg_fps');
+    createChart('gen-watts-chart', 'Average Power Usage by Test Type', 'Watts', 'avg_watts');
+    createChart('gen-efficiency-chart', 'Efficiency (FPS per Watt) by Test Type', 'FPS/Watt', 'fps_per_watt');
+  }
+
+  // Check if Chart.js is already loaded
+  if (typeof Chart !== 'undefined') {
+    initCharts();
+  } else {
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/chart.js';
+    script.onload = initCharts;
+    document.head.appendChild(script);
+  }
+</script>
+)}

--- a/web/src/pages/gpu/arc/alchemist.astro
+++ b/web/src/pages/gpu/arc/alchemist.astro
@@ -1,0 +1,445 @@
+---
+/**
+ * Arc Alchemist (A-Series) Page
+ */
+import Layout from '../../../layouts/Layout.astro';
+import CodecMatrix from '../../../components/generation/CodecMatrix.astro';
+import ArchitectureCard from '../../../components/generation/ArchitectureCard.astro';
+
+const API_BASE = import.meta.env.PUBLIC_API_URL || 'https://quicksync-api.ktz.me';
+
+let arcData: any = null;
+let error: string | null = null;
+
+try {
+  const response = await fetch(`${API_BASE}/api/results/arc-models?architecture=Arc Alchemist`);
+  if (response.ok) {
+    arcData = await response.json();
+    if (!arcData.success) {
+      error = arcData.error || 'Failed to load Arc Alchemist data';
+    }
+  } else {
+    error = `API error: ${response.status}`;
+  }
+} catch (e) {
+  error = 'Failed to connect to API';
+}
+
+const archInfo = arcData?.architectures?.find((a: any) => a.architecture === 'Arc Alchemist');
+const codecSupport = archInfo?.codec_support || {
+  h264_encode: true,
+  hevc_8bit_encode: true,
+  hevc_10bit_encode: true,
+  vp9_encode: true,
+  av1_encode: true,
+};
+
+// Map architecture info to the format ArchitectureCard expects
+const architectureData = archInfo ? {
+  name: 'Arc Alchemist',
+  codename: archInfo.codename || 'DG2',
+  release_year: archInfo.release_year || 2022,
+  igpu_name: archInfo.igpu_name || 'Intel Arc A-Series',
+  igpu_codename: archInfo.igpu_codename || 'Xe-HPG',
+  process_nm: archInfo.process_nm || 'TSMC N6',
+  max_p_cores: null,
+  max_e_cores: null,
+  tdp_range: archInfo.tdp_range || '75-225W',
+  die_layout: archInfo.die_layout || 'Discrete GPU (ACM-G10/G11)',
+  gpu_eu_count: archInfo.gpu_eu_count || '128-512 EU',
+} : null;
+
+function cleanModelName(name: string): string {
+  return name.replace(/^Intel\s*/i, '').replace(/^Arc\s*/i, '').trim();
+}
+---
+
+<Layout title="Arc Alchemist (A-Series) - QuickSync Benchmarks">
+  <div class="container">
+    <div class="page-header">
+      <h1>Arc Alchemist</h1>
+      <p class="subtitle">Intel's first-generation discrete GPUs (A-Series)</p>
+    </div>
+
+    {error ? (
+      <div class="error-state card">
+        <p>{error}</p>
+        <a href="/gpu/arc/all">&larr; Back to All Arc GPUs</a>
+      </div>
+    ) : arcData ? (
+      <>
+        {/* TL;DR */}
+        <section class="tldr card">
+          <h2>TL;DR</h2>
+          <p>
+            <strong>Arc Alchemist</strong> (codenamed DG2) is Intel's first-generation discrete GPU architecture,
+            launched in 2022. The A-Series includes models from the entry-level A380 to the flagship A770.
+            All models feature <strong>full AV1 hardware encoding</strong> and dual media engines for high throughput.
+          </p>
+        </section>
+
+        {/* Navigation tabs */}
+        <nav class="arch-nav">
+          <a href="/gpu/arc/all" class="arch-tab">All Models</a>
+          <a href="/gpu/arc/alchemist" class="arch-tab active">Alchemist (A-Series)</a>
+          <a href="/gpu/arc/battlemage" class="arch-tab">Battlemage (B-Series)</a>
+        </nav>
+
+        {/* Architecture Details */}
+        <div class="info-grid">
+          {architectureData && (
+            <section class="card">
+              <h2>Architecture</h2>
+              <ArchitectureCard architecture={architectureData} />
+            </section>
+          )}
+
+          <section class="card">
+            <h2>Codec Support</h2>
+            <CodecMatrix codecSupport={codecSupport} />
+          </section>
+        </div>
+
+        {/* Models */}
+        <section class="models-section card">
+          <h2>
+            A-Series Models
+            <span class="model-count">{arcData.models.length} {arcData.models.length === 1 ? 'model' : 'models'}</span>
+          </h2>
+
+          {arcData.models.length === 0 ? (
+            <p class="no-data">No benchmark data available yet. <a href="/about">Learn how to contribute</a>.</p>
+          ) : (
+            <div class="models-grid">
+              {arcData.models.map((model: any) => (
+                <div class="model-card">
+                  <h3 class="model-name">{cleanModelName(model.model_name)}</h3>
+                  <div class="model-stats">
+                    <span class="stat-item">
+                      <span class="stat-label">Results</span>
+                      <span class="stat-value">{model.total_results}</span>
+                    </span>
+                  </div>
+
+                  {model.by_test.length > 0 && (
+                    <table class="model-results">
+                      <thead>
+                        <tr>
+                          <th>Test</th>
+                          <th class="numeric">FPS</th>
+                          <th class="numeric">FPS/W</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {model.by_test.map((test: any) => (
+                          <tr>
+                            <td>
+                              <span class:list={['test-badge', test.test_name.includes('hevc') ? 'hevc' : test.test_name.includes('av1') ? 'av1' : 'h264']}>
+                                {test.test_name}
+                              </span>
+                            </td>
+                            <td class="numeric">{test.avg_fps?.toFixed(1) || '—'}</td>
+                            <td class="numeric">{test.fps_per_watt?.toFixed(2) || '—'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Known Models Info */}
+        <section class="card">
+          <h2>Alchemist Model Lineup</h2>
+          <table class="specs-table">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>GPU Die</th>
+                <th>Xe-Cores</th>
+                <th>VRAM</th>
+                <th>TDP</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Arc A770</td>
+                <td>ACM-G10</td>
+                <td>32</td>
+                <td>16GB GDDR6</td>
+                <td>225W</td>
+              </tr>
+              <tr>
+                <td>Arc A750</td>
+                <td>ACM-G10</td>
+                <td>28</td>
+                <td>8GB GDDR6</td>
+                <td>225W</td>
+              </tr>
+              <tr>
+                <td>Arc A580</td>
+                <td>ACM-G10</td>
+                <td>24</td>
+                <td>8GB GDDR6</td>
+                <td>185W</td>
+              </tr>
+              <tr>
+                <td>Arc A380</td>
+                <td>ACM-G11</td>
+                <td>8</td>
+                <td>6GB GDDR6</td>
+                <td>75W</td>
+              </tr>
+              <tr>
+                <td>Arc A310</td>
+                <td>ACM-G11</td>
+                <td>6</td>
+                <td>4GB GDDR6</td>
+                <td>75W</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        {/* Pricing */}
+        <section class="pricing-section card">
+          <h2>Find Arc Alchemist GPUs</h2>
+          <div class="pricing-links">
+            <a href="https://www.ebay.com/sch/i.html?_nkw=intel+arc+a770" target="_blank" rel="noopener" class="pricing-link">A770 on eBay</a>
+            <a href="https://www.ebay.com/sch/i.html?_nkw=intel+arc+a750" target="_blank" rel="noopener" class="pricing-link">A750 on eBay</a>
+            <a href="https://www.ebay.com/sch/i.html?_nkw=intel+arc+a380" target="_blank" rel="noopener" class="pricing-link">A380 on eBay</a>
+            <a href="https://www.amazon.com/s?k=intel+arc+a770" target="_blank" rel="noopener" class="pricing-link">Amazon</a>
+          </div>
+        </section>
+      </>
+    ) : (
+      <div class="loading-state">Loading...</div>
+    )}
+  </div>
+</Layout>
+
+<style>
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1rem;
+  }
+
+  .page-header {
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+
+  .page-header h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0;
+  }
+
+  .subtitle {
+    color: var(--color-text-muted);
+    margin-top: 0.5rem;
+  }
+
+  section {
+    margin-bottom: 1.5rem;
+  }
+
+  section h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .model-count {
+    font-size: 0.75rem;
+    font-weight: 400;
+    color: var(--color-text-muted);
+  }
+
+  .tldr p {
+    line-height: 1.7;
+  }
+
+  /* Info Grid */
+  .info-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+  }
+
+  @media (max-width: 768px) {
+    .info-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Navigation */
+  .arch-nav {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .arch-tab {
+    padding: 0.5rem 1rem;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    transition: all 0.2s;
+  }
+
+  .arch-tab:hover {
+    border-color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  .arch-tab.active {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: white;
+  }
+
+  /* Models Grid */
+  .models-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+  }
+
+  .model-card {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 1rem;
+  }
+
+  .model-name {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 0 0 0.75rem;
+  }
+
+  .model-stats {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .stat-item {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .stat-label {
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+  }
+
+  .stat-value {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .model-results {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+  }
+
+  .model-results th,
+  .model-results td {
+    padding: 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .model-results th.numeric,
+  .model-results td.numeric {
+    text-align: right;
+  }
+
+  .model-results th {
+    font-weight: 500;
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+  }
+
+  .test-badge {
+    display: inline-block;
+    padding: 0.0625rem 0.375rem;
+    border-radius: 0.125rem;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    background-color: var(--color-bg-secondary);
+  }
+
+  .test-badge.h264 { color: #22c55e; }
+  .test-badge.hevc { color: #3b82f6; }
+  .test-badge.av1 { color: #a855f7; }
+
+  /* Specs Table */
+  .specs-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+
+  .specs-table th,
+  .specs-table td {
+    padding: 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .specs-table th {
+    font-weight: 500;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+  }
+
+  /* Pricing */
+  .pricing-links {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .pricing-link {
+    padding: 0.5rem 1rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    transition: all 0.2s;
+  }
+
+  .pricing-link:hover {
+    border-color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  .no-data {
+    color: var(--color-text-muted);
+    text-align: center;
+    padding: 2rem;
+  }
+
+  .error-state, .loading-state {
+    text-align: center;
+    padding: 2rem;
+  }
+</style>

--- a/web/src/pages/gpu/arc/all.astro
+++ b/web/src/pages/gpu/arc/all.astro
@@ -1,0 +1,442 @@
+---
+/**
+ * All Arc GPUs Page
+ * Shows all Arc GPU models with individual stats (not merged)
+ */
+import Layout from '../../../layouts/Layout.astro';
+import CodecMatrix from '../../../components/generation/CodecMatrix.astro';
+
+const API_BASE = import.meta.env.PUBLIC_API_URL || 'https://quicksync-api.ktz.me';
+
+let arcData: any = null;
+let error: string | null = null;
+
+try {
+  const response = await fetch(`${API_BASE}/api/results/arc-models`);
+  if (response.ok) {
+    arcData = await response.json();
+    if (!arcData.success) {
+      error = arcData.error || 'Failed to load Arc GPU data';
+    }
+  } else {
+    error = `API error: ${response.status}`;
+  }
+} catch (e) {
+  error = 'Failed to connect to API';
+}
+
+// Group models by architecture
+const modelsByArch: Record<string, any[]> = {};
+if (arcData?.models) {
+  for (const model of arcData.models) {
+    if (!modelsByArch[model.architecture]) {
+      modelsByArch[model.architecture] = [];
+    }
+    modelsByArch[model.architecture].push(model);
+  }
+}
+
+// Get codec support from first architecture
+const codecSupport = arcData?.architectures?.[0]?.codec_support || {
+  h264_encode: true,
+  hevc_8bit_encode: true,
+  hevc_10bit_encode: true,
+  vp9_encode: true,
+  av1_encode: true,
+};
+
+// Strip "Arc" prefix from model name for display
+function cleanModelName(name: string): string {
+  return name.replace(/^Intel\s*/i, '').replace(/^Arc\s*/i, '').trim();
+}
+---
+
+<Layout title="Intel Arc GPUs - QuickSync Benchmarks">
+  <div class="container">
+    <div class="page-header">
+      <h1>Intel Arc GPUs</h1>
+      <p class="subtitle">Discrete GPU hardware encoding benchmark comparison</p>
+    </div>
+
+    {error ? (
+      <div class="error-state card">
+        <p>{error}</p>
+        <a href="/" class="back-link">&larr; Back to Dashboard</a>
+      </div>
+    ) : arcData ? (
+      <>
+        {/* TL;DR */}
+        <section class="tldr card">
+          <h2>TL;DR</h2>
+          <p>
+            Intel Arc GPUs feature <strong>full hardware encoding support</strong> including AV1, making them
+            excellent choices for video transcoding. They support H.264, HEVC (8-bit and 10-bit), VP9, and AV1
+            encoding - the most complete codec support in Intel's lineup.
+          </p>
+        </section>
+
+        {/* Navigation tabs */}
+        <nav class="arch-nav">
+          <a href="/gpu/arc/all" class="arch-tab active">All Models</a>
+          <a href="/gpu/arc/alchemist" class="arch-tab">Alchemist (A-Series)</a>
+          <a href="/gpu/arc/battlemage" class="arch-tab">Battlemage (B-Series)</a>
+        </nav>
+
+        {/* Codec Support */}
+        <section class="card">
+          <h2>Codec Support</h2>
+          <CodecMatrix codecSupport={codecSupport} />
+        </section>
+
+        {/* Models by Architecture */}
+        {Object.entries(modelsByArch).map(([arch, models]) => (
+          <section class="models-section card">
+            <h2>
+              {arch}
+              <span class="model-count">{models.length} {models.length === 1 ? 'model' : 'models'}</span>
+            </h2>
+
+            <div class="models-grid">
+              {models.map((model: any) => (
+                <div class="model-card">
+                  <h3 class="model-name">{cleanModelName(model.model_name)}</h3>
+                  <div class="model-stats">
+                    <span class="stat-item">
+                      <span class="stat-label">Results</span>
+                      <span class="stat-value">{model.total_results}</span>
+                    </span>
+                  </div>
+
+                  {model.by_test.length > 0 && (
+                    <table class="model-results">
+                      <thead>
+                        <tr>
+                          <th>Test</th>
+                          <th class="numeric">FPS</th>
+                          <th class="numeric">FPS/W</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {model.by_test.map((test: any) => (
+                          <tr>
+                            <td>
+                              <span class:list={['test-badge', test.test_name.includes('hevc') ? 'hevc' : test.test_name.includes('av1') ? 'av1' : 'h264']}>
+                                {test.test_name}
+                              </span>
+                            </td>
+                            <td class="numeric">{test.avg_fps?.toFixed(1) || '—'}</td>
+                            <td class="numeric">{test.fps_per_watt?.toFixed(2) || '—'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        {/* Comparison Table */}
+        {arcData.models.length > 0 && arcData.all_tests.length > 0 && (
+          <section class="comparison-section card">
+            <h2>Performance Comparison</h2>
+            <div class="comparison-table-wrapper">
+              <table class="comparison-table">
+                <thead>
+                  <tr>
+                    <th>GPU</th>
+                    <th>Architecture</th>
+                    {arcData.all_tests.map((test: string) => (
+                      <th class="numeric">{test}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {arcData.models.map((model: any) => (
+                    <tr>
+                      <td class="model-name-cell">{cleanModelName(model.model_name)}</td>
+                      <td>{model.architecture.replace('Arc ', '')}</td>
+                      {arcData.all_tests.map((testName: string) => {
+                        const test = model.by_test.find((t: any) => t.test_name === testName);
+                        return (
+                          <td class="numeric">{test?.avg_fps?.toFixed(1) || '—'}</td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* Pricing Links */}
+        <section class="pricing-section card">
+          <h2>Find Arc GPUs</h2>
+          <p class="pricing-note">Search for Intel Arc GPUs on popular marketplaces:</p>
+          <div class="pricing-links">
+            <a href="https://www.ebay.com/sch/i.html?_nkw=intel+arc+gpu" target="_blank" rel="noopener" class="pricing-link">
+              eBay
+            </a>
+            <a href="https://www.amazon.com/s?k=intel+arc+gpu" target="_blank" rel="noopener" class="pricing-link">
+              Amazon
+            </a>
+            <a href="https://www.newegg.com/p/pl?d=intel+arc" target="_blank" rel="noopener" class="pricing-link">
+              Newegg
+            </a>
+            <a href="https://www.bhphotovideo.com/c/search?q=intel+arc" target="_blank" rel="noopener" class="pricing-link">
+              B&H Photo
+            </a>
+          </div>
+        </section>
+      </>
+    ) : (
+      <div class="loading-state">
+        <p>Loading...</p>
+      </div>
+    )}
+  </div>
+</Layout>
+
+<style>
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1rem;
+  }
+
+  .page-header {
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+
+  .page-header h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0;
+  }
+
+  .subtitle {
+    color: var(--color-text-muted);
+    margin-top: 0.5rem;
+  }
+
+  section {
+    margin-bottom: 1.5rem;
+  }
+
+  section h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .model-count {
+    font-size: 0.75rem;
+    font-weight: 400;
+    color: var(--color-text-muted);
+  }
+
+  /* TL;DR */
+  .tldr p {
+    line-height: 1.7;
+  }
+
+  /* Architecture Navigation */
+  .arch-nav {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .arch-tab {
+    padding: 0.5rem 1rem;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    transition: all 0.2s;
+  }
+
+  .arch-tab:hover {
+    border-color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  .arch-tab.active {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: white;
+  }
+
+  /* Models Grid */
+  .models-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 1rem;
+  }
+
+  .model-card {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 1rem;
+  }
+
+  .model-name {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 0 0 0.75rem;
+  }
+
+  .model-stats {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .stat-item {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .stat-label {
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+  }
+
+  .stat-value {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .model-results {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+  }
+
+  .model-results th {
+    text-align: left;
+    padding: 0.5rem;
+    font-weight: 500;
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .model-results th.numeric {
+    text-align: right;
+  }
+
+  .model-results td {
+    padding: 0.5rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .model-results td.numeric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .test-badge {
+    display: inline-block;
+    padding: 0.0625rem 0.375rem;
+    border-radius: 0.125rem;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    background-color: var(--color-bg-secondary);
+  }
+
+  .test-badge.h264 { color: #22c55e; }
+  .test-badge.hevc { color: #3b82f6; }
+  .test-badge.av1 { color: #a855f7; }
+
+  /* Comparison Table */
+  .comparison-table-wrapper {
+    overflow-x: auto;
+  }
+
+  .comparison-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+
+  .comparison-table th {
+    text-align: left;
+    padding: 0.75rem;
+    font-weight: 500;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    border-bottom: 2px solid var(--color-border);
+    white-space: nowrap;
+  }
+
+  .comparison-table th.numeric {
+    text-align: right;
+  }
+
+  .comparison-table td {
+    padding: 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .comparison-table td.numeric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .model-name-cell {
+    font-weight: 500;
+  }
+
+  /* Pricing */
+  .pricing-note {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    margin-bottom: 1rem;
+  }
+
+  .pricing-links {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .pricing-link {
+    padding: 0.5rem 1rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    transition: all 0.2s;
+  }
+
+  .pricing-link:hover {
+    border-color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  /* States */
+  .error-state, .loading-state {
+    text-align: center;
+    padding: 2rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    margin-top: 1rem;
+    color: var(--color-accent);
+  }
+</style>

--- a/web/src/pages/gpu/arc/battlemage.astro
+++ b/web/src/pages/gpu/arc/battlemage.astro
@@ -1,0 +1,474 @@
+---
+/**
+ * Arc Battlemage (B-Series) Page
+ */
+import Layout from '../../../layouts/Layout.astro';
+import CodecMatrix from '../../../components/generation/CodecMatrix.astro';
+import ArchitectureCard from '../../../components/generation/ArchitectureCard.astro';
+
+const API_BASE = import.meta.env.PUBLIC_API_URL || 'https://quicksync-api.ktz.me';
+
+let arcData: any = null;
+let error: string | null = null;
+
+try {
+  const response = await fetch(`${API_BASE}/api/results/arc-models?architecture=Arc Battlemage`);
+  if (response.ok) {
+    arcData = await response.json();
+    if (!arcData.success) {
+      error = arcData.error || 'Failed to load Arc Battlemage data';
+    }
+  } else {
+    error = `API error: ${response.status}`;
+  }
+} catch (e) {
+  error = 'Failed to connect to API';
+}
+
+const archInfo = arcData?.architectures?.find((a: any) => a.architecture === 'Arc Battlemage');
+const codecSupport = archInfo?.codec_support || {
+  h264_encode: true,
+  hevc_8bit_encode: true,
+  hevc_10bit_encode: true,
+  vp9_encode: true,
+  av1_encode: true,
+};
+
+// Map architecture info to the format ArchitectureCard expects
+const architectureData = archInfo ? {
+  name: 'Arc Battlemage',
+  codename: archInfo.codename || 'BMG',
+  release_year: archInfo.release_year || 2024,
+  igpu_name: archInfo.igpu_name || 'Intel Arc B-Series',
+  igpu_codename: archInfo.igpu_codename || 'Xe2-HPG',
+  process_nm: archInfo.process_nm || 'TSMC N4',
+  max_p_cores: null,
+  max_e_cores: null,
+  tdp_range: archInfo.tdp_range || '150W',
+  die_layout: archInfo.die_layout || 'Discrete GPU (BMG-G21)',
+  gpu_eu_count: archInfo.gpu_eu_count || '160 EU',
+} : null;
+
+function cleanModelName(name: string): string {
+  return name.replace(/^Intel\s*/i, '').replace(/^Arc\s*/i, '').trim();
+}
+---
+
+<Layout title="Arc Battlemage (B-Series) - QuickSync Benchmarks">
+  <div class="container">
+    <div class="page-header">
+      <h1>Arc Battlemage</h1>
+      <p class="subtitle">Intel's second-generation discrete GPUs (B-Series)</p>
+    </div>
+
+    {error ? (
+      <div class="error-state card">
+        <p>{error}</p>
+        <a href="/gpu/arc/all">&larr; Back to All Arc GPUs</a>
+      </div>
+    ) : arcData ? (
+      <>
+        {/* TL;DR */}
+        <section class="tldr card">
+          <h2>TL;DR</h2>
+          <p>
+            <strong>Arc Battlemage</strong> (codenamed BMG) is Intel's second-generation discrete GPU architecture,
+            launching in late 2024. Built on the Xe2 architecture and TSMC N4 process, Battlemage brings
+            significant efficiency improvements over Alchemist while maintaining <strong>full AV1 hardware encoding</strong>
+            support. The B580 launched at $249 targeting mainstream gaming and content creation.
+          </p>
+        </section>
+
+        {/* Navigation tabs */}
+        <nav class="arch-nav">
+          <a href="/gpu/arc/all" class="arch-tab">All Models</a>
+          <a href="/gpu/arc/alchemist" class="arch-tab">Alchemist (A-Series)</a>
+          <a href="/gpu/arc/battlemage" class="arch-tab active">Battlemage (B-Series)</a>
+        </nav>
+
+        {/* Architecture Details */}
+        <div class="info-grid">
+          {architectureData && (
+            <section class="card">
+              <h2>Architecture</h2>
+              <ArchitectureCard architecture={architectureData} />
+            </section>
+          )}
+
+          <section class="card">
+            <h2>Codec Support</h2>
+            <CodecMatrix codecSupport={codecSupport} />
+          </section>
+        </div>
+
+        {/* Models */}
+        <section class="models-section card">
+          <h2>
+            B-Series Models
+            <span class="model-count">{arcData.models.length} {arcData.models.length === 1 ? 'model' : 'models'}</span>
+          </h2>
+
+          {arcData.models.length === 0 ? (
+            <p class="no-data">
+              No benchmark data available yet for Battlemage GPUs.
+              <br />
+              <a href="/about">Learn how to contribute your results</a>.
+            </p>
+          ) : (
+            <div class="models-grid">
+              {arcData.models.map((model: any) => (
+                <div class="model-card">
+                  <h3 class="model-name">{cleanModelName(model.model_name)}</h3>
+                  <div class="model-stats">
+                    <span class="stat-item">
+                      <span class="stat-label">Results</span>
+                      <span class="stat-value">{model.total_results}</span>
+                    </span>
+                  </div>
+
+                  {model.by_test.length > 0 && (
+                    <table class="model-results">
+                      <thead>
+                        <tr>
+                          <th>Test</th>
+                          <th class="numeric">FPS</th>
+                          <th class="numeric">FPS/W</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {model.by_test.map((test: any) => (
+                          <tr>
+                            <td>
+                              <span class:list={['test-badge', test.test_name.includes('hevc') ? 'hevc' : test.test_name.includes('av1') ? 'av1' : 'h264']}>
+                                {test.test_name}
+                              </span>
+                            </td>
+                            <td class="numeric">{test.avg_fps?.toFixed(1) || '—'}</td>
+                            <td class="numeric">{test.fps_per_watt?.toFixed(2) || '—'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Known Models Info */}
+        <section class="card">
+          <h2>Battlemage Model Lineup</h2>
+          <table class="specs-table">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>GPU Die</th>
+                <th>Xe2-Cores</th>
+                <th>VRAM</th>
+                <th>TDP</th>
+                <th>MSRP</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Arc B580</td>
+                <td>BMG-G21</td>
+                <td>20</td>
+                <td>12GB GDDR6</td>
+                <td>150W</td>
+                <td>$249</td>
+              </tr>
+              <tr class="upcoming">
+                <td>Arc B570</td>
+                <td>BMG-G21</td>
+                <td>18</td>
+                <td>10GB GDDR6</td>
+                <td>150W</td>
+                <td>$219 (expected)</td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="specs-note">* B570 specs are based on early reports and may change at launch.</p>
+        </section>
+
+        {/* What's New */}
+        <section class="card">
+          <h2>What's New in Xe2</h2>
+          <ul class="feature-list">
+            <li><strong>Xe2-HPG Architecture</strong> - Second-generation discrete GPU design</li>
+            <li><strong>TSMC N4 Process</strong> - Improved power efficiency over N6</li>
+            <li><strong>12GB VRAM</strong> - More memory than competing GPUs at this price</li>
+            <li><strong>XeSS 2 / Frame Generation</strong> - New AI-powered upscaling and frame generation</li>
+            <li><strong>Hardware Ray Tracing</strong> - Improved RT performance</li>
+            <li><strong>Full Media Engine</strong> - AV1, HEVC 10-bit, VP9 encode support</li>
+          </ul>
+        </section>
+
+        {/* Pricing */}
+        <section class="pricing-section card">
+          <h2>Find Arc Battlemage GPUs</h2>
+          <div class="pricing-links">
+            <a href="https://www.ebay.com/sch/i.html?_nkw=intel+arc+b580" target="_blank" rel="noopener" class="pricing-link">B580 on eBay</a>
+            <a href="https://www.amazon.com/s?k=intel+arc+b580" target="_blank" rel="noopener" class="pricing-link">B580 on Amazon</a>
+            <a href="https://www.newegg.com/p/pl?d=intel+arc+b580" target="_blank" rel="noopener" class="pricing-link">B580 on Newegg</a>
+            <a href="https://www.bhphotovideo.com/c/search?q=intel+arc+b580" target="_blank" rel="noopener" class="pricing-link">B&H Photo</a>
+          </div>
+        </section>
+      </>
+    ) : (
+      <div class="loading-state">Loading...</div>
+    )}
+  </div>
+</Layout>
+
+<style>
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1rem;
+  }
+
+  .page-header {
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+
+  .page-header h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0;
+  }
+
+  .subtitle {
+    color: var(--color-text-muted);
+    margin-top: 0.5rem;
+  }
+
+  section {
+    margin-bottom: 1.5rem;
+  }
+
+  section h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .model-count {
+    font-size: 0.75rem;
+    font-weight: 400;
+    color: var(--color-text-muted);
+  }
+
+  .tldr p {
+    line-height: 1.7;
+  }
+
+  /* Info Grid */
+  .info-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+  }
+
+  @media (max-width: 768px) {
+    .info-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Navigation */
+  .arch-nav {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .arch-tab {
+    padding: 0.5rem 1rem;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    transition: all 0.2s;
+  }
+
+  .arch-tab:hover {
+    border-color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  .arch-tab.active {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: white;
+  }
+
+  /* Models Grid */
+  .models-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+  }
+
+  .model-card {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 1rem;
+  }
+
+  .model-name {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 0 0 0.75rem;
+  }
+
+  .model-stats {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .stat-item {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .stat-label {
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+  }
+
+  .stat-value {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .model-results {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+  }
+
+  .model-results th,
+  .model-results td {
+    padding: 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .model-results th.numeric,
+  .model-results td.numeric {
+    text-align: right;
+  }
+
+  .model-results th {
+    font-weight: 500;
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+  }
+
+  .test-badge {
+    display: inline-block;
+    padding: 0.0625rem 0.375rem;
+    border-radius: 0.125rem;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    background-color: var(--color-bg-secondary);
+  }
+
+  .test-badge.h264 { color: #22c55e; }
+  .test-badge.hevc { color: #3b82f6; }
+  .test-badge.av1 { color: #a855f7; }
+
+  /* Specs Table */
+  .specs-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+
+  .specs-table th,
+  .specs-table td {
+    padding: 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .specs-table th {
+    font-weight: 500;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+  }
+
+  .specs-table tr.upcoming {
+    opacity: 0.7;
+  }
+
+  .specs-note {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    margin-top: 0.75rem;
+    font-style: italic;
+  }
+
+  /* Feature List */
+  .feature-list {
+    list-style: none;
+    padding: 0;
+  }
+
+  .feature-list li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 0.875rem;
+  }
+
+  .feature-list li:last-child {
+    border-bottom: none;
+  }
+
+  /* Pricing */
+  .pricing-links {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .pricing-link {
+    padding: 0.5rem 1rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    transition: all 0.2s;
+  }
+
+  .pricing-link:hover {
+    border-color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  .no-data {
+    color: var(--color-text-muted);
+    text-align: center;
+    padding: 2rem;
+    line-height: 1.8;
+  }
+
+  .error-state, .loading-state {
+    text-align: center;
+    padding: 2rem;
+  }
+</style>

--- a/web/src/pages/gpu/arc/index.astro
+++ b/web/src/pages/gpu/arc/index.astro
@@ -1,0 +1,6 @@
+---
+/**
+ * Arc GPU index page - redirects to /gpu/arc/all
+ */
+return Astro.redirect('/gpu/arc/all');
+---

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -737,6 +737,18 @@ cd quicksync_calc
   .cpu-stats-panel .gen-stats-header h3 {
     color: #22c55e;
   }
+
+  /* CPU Links */
+  .cpu-link {
+    color: var(--color-text);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+
+  .cpu-link:hover {
+    color: var(--color-accent);
+    text-decoration: underline;
+  }
 </style>
 
 <script define:vars={{ API_URL }}>
@@ -979,6 +991,37 @@ cd quicksync_calc
       .replace(/\s*\d{1,2}th Gen\s*/gi, '') // Remove "13th Gen" etc
       .replace(/\s+/g, ' ')
       .trim();
+  }
+
+  // Generate a link to the CPU's generation page
+  function getCpuLink(cpuRaw, architecture, generation) {
+    // Arc GPUs link to Arc pages
+    if (architecture && (architecture.includes('Arc') || architecture === 'Alchemist' || architecture === 'Battlemage')) {
+      return '/gpu/arc/all';
+    }
+    // Meteor Lake links to Ultra Series 1
+    if (architecture === 'Meteor Lake') {
+      return '/cpu/gen/ultra-1';
+    }
+    // Arrow Lake or Lunar Lake links to Ultra Series 2
+    if (architecture === 'Arrow Lake' || architecture === 'Lunar Lake') {
+      return '/cpu/gen/ultra-2';
+    }
+    // Standard generations 2-14
+    if (generation && generation >= 2 && generation <= 14) {
+      return `/cpu/gen/${generation}`;
+    }
+    return null;
+  }
+
+  // Render CPU name with optional link to generation page
+  function renderCpuName(cpuRaw, architecture, generation) {
+    const displayName = stripIntelBranding(cpuRaw);
+    const link = getCpuLink(cpuRaw, architecture, generation);
+    if (link) {
+      return `<a href="${link}" class="cpu-link" title="${cpuRaw}">${displayName}</a>`;
+    }
+    return `<span title="${cpuRaw}">${displayName}</span>`;
   }
 
   // Render CPU list (filtered by search and with counts)
@@ -1982,13 +2025,13 @@ cd quicksync_calc
     tbody.innerHTML = results.map(r => {
       const testClass = r.test_name.includes('cpu') ? 'cpu' : r.test_name.includes('hevc') ? 'hevc' : 'h264';
       const date = new Date(r.submitted_at).toLocaleDateString();
-      const displayCpu = stripIntelBranding(r.cpu_raw);
+      const cpuHtml = renderCpuName(r.cpu_raw, r.architecture, r.cpu_generation);
       const score = cpuScores[r.cpu_raw];
       const scoreClass = score >= 70 ? 'score-high' : score >= 40 ? 'score-mid' : 'score-low';
 
       return `
         <tr>
-          <td class="cpu-cell" title="${r.cpu_raw}">${displayCpu}</td>
+          <td class="cpu-cell">${cpuHtml}</td>
           <td>${r.architecture || '-'}</td>
           <td><span class="test-badge ${testClass}">${r.test_name}</span></td>
           <td class="numeric">${r.avg_fps?.toFixed(1) || '-'}</td>

--- a/web/src/pages/leaderboard.astro
+++ b/web/src/pages/leaderboard.astro
@@ -289,6 +289,17 @@ const API_URL = import.meta.env.PUBLIC_API_URL || 'https://quicksync-api.ktz.me'
     font-weight: 500;
   }
 
+  .cpu-link {
+    color: var(--color-text);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+
+  .cpu-link:hover {
+    color: var(--color-accent);
+    text-decoration: underline;
+  }
+
   /* Methodology Section */
   .methodology-section {
     margin-top: 3rem;
@@ -387,6 +398,37 @@ const API_URL = import.meta.env.PUBLIC_API_URL || 'https://quicksync-api.ktz.me'
       .trim();
   }
 
+  // Generate a link to the CPU's generation page
+  function getCpuLink(architecture, generation) {
+    // Arc GPUs link to Arc pages
+    if (architecture && (architecture.includes('Arc') || architecture === 'Alchemist' || architecture === 'Battlemage')) {
+      return '/gpu/arc/all';
+    }
+    // Meteor Lake links to Ultra Series 1
+    if (architecture === 'Meteor Lake') {
+      return '/cpu/gen/ultra-1';
+    }
+    // Arrow Lake or Lunar Lake links to Ultra Series 2
+    if (architecture === 'Arrow Lake' || architecture === 'Lunar Lake') {
+      return '/cpu/gen/ultra-2';
+    }
+    // Standard generations 2-14
+    if (generation && generation >= 2 && generation <= 14) {
+      return `/cpu/gen/${generation}`;
+    }
+    return null;
+  }
+
+  // Render CPU name with optional link to generation page
+  function renderCpuName(cpuRaw, architecture, generation) {
+    const displayName = stripIntelBranding(cpuRaw);
+    const link = getCpuLink(architecture, generation);
+    if (link) {
+      return `<a href="${link}" class="cpu-link" title="${cpuRaw}">${displayName}</a>`;
+    }
+    return `<span title="${cpuRaw}">${displayName}</span>`;
+  }
+
   // Fetch scores from API
   async function fetchScores() {
     try {
@@ -450,12 +492,12 @@ const API_URL = import.meta.env.PUBLIC_API_URL || 'https://quicksync-api.ktz.me'
       const rank = index + 1;
       const rankClass = rank <= 3 ? `rank-${rank}` : 'rank-other';
       const scoreClass = cpu.score >= 70 ? 'score-high' : cpu.score >= 40 ? 'score-mid' : 'score-low';
-      const displayName = stripIntelBranding(cpu.cpu_raw);
+      const cpuHtml = renderCpuName(cpu.cpu_raw, cpu.architecture, cpu.cpu_generation);
 
       return `
         <tr>
           <td><span class="rank-badge ${rankClass}">${rank}</span></td>
-          <td class="cpu-name" title="${cpu.cpu_raw}">${displayName}</td>
+          <td class="cpu-name">${cpuHtml}</td>
           <td>${cpu.architecture || '-'}</td>
           <td class="numeric"><span class="score-badge ${scoreClass}">${cpu.score}</span></td>
         </tr>


### PR DESCRIPTION
## Summary

- Add per-generation detail pages at `/cpu/gen/[gen]` with timeline slider, TL;DR stats, architecture details, codec support matrix, and CPU model table
- Add Arc GPU pages at `/gpu/arc/` with individual model breakdowns (Alchemist & Battlemage)
- API enhancements for generation detail and Arc model endpoints
- Support for multiple iGPU variants in 12th-14th gen (UHD 730 vs UHD 770)
- Score-based CPU ranking for accurate "Top Performer" display

## Test plan

- [ ] Visit `/cpu/gen/8` through `/cpu/gen/14` - verify timeline, stats, charts display correctly
- [ ] Visit `/cpu/gen/12`, `/cpu/gen/13`, `/cpu/gen/14` - verify iGPU variant info shows (UHD 730 vs 770)
- [ ] Visit `/cpu/gen/arc` - verify Arc GPU page with timeline separator
- [ ] Visit `/gpu/arc/all` - verify individual Arc model comparison
- [ ] Check "Top Performer" callout uses score-based ranking (not FPS)
- [ ] Verify nav link "CPU Generations" appears in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)