### PR TITLE
Fix Arc GPU detection and pricing link generation

### DIFF
--- a/api/src/lib/cpu-parser.ts
+++ b/api/src/lib/cpu-parser.ts
@@ -81,6 +81,9 @@ const CPU_PATTERNS: ArchitecturePattern[] = [
   // AMD EPYC (server CPUs - no iGPU, but may be paired with discrete GPU)
   { pattern: /EPYC\s*7\d{3}/, architecture: 'AMD EPYC Rome/Milan', codename: 'Rome/Milan', releaseYear: 2019, sortOrder: 300 },
   { pattern: /EPYC\s*9\d{3}/, architecture: 'AMD EPYC Genoa', codename: 'Genoa', releaseYear: 2022, sortOrder: 310 },
+  // Intel Arc GPUs (discrete)
+  { pattern: /Arc\s*A\d{2,3}/, architecture: 'Arc Alchemist', codename: 'DG2', releaseYear: 2022, sortOrder: 145 },
+  { pattern: /Arc\s*B\d{3}/, architecture: 'Arc Battlemage', codename: 'BMG', releaseYear: 2024, sortOrder: 147 },
 ];
 
 /**

--- a/scripts/backfill-architectures.py
+++ b/scripts/backfill-architectures.py
@@ -88,9 +88,9 @@ CPU_PATTERNS = [
     (r'Silver.*\d{4}', 'Gemini Lake', None),
     (r'^Silver$', 'Gemini Lake', None),  # Bare "Silver" (likely truncated Pentium Silver)
 
-    # Intel Arc GPUs
-    (r'Arc\s*A\d{2,3}', 'Alchemist', 1),   # Arc A-series (A770, A750, A380, A40 Pro, etc.)
-    (r'Arc\s*B\d{3}', 'Battlemage', 2),    # Arc B-series (B580, B570)
+    # Intel Arc GPUs (discrete - no cpu_generation, identified by architecture name)
+    (r'Arc\s*A\d{2,3}', 'Arc Alchemist', None),   # Arc A-series (A770, A750, A380, A40 Pro, etc.)
+    (r'Arc\s*B\d{3}', 'Arc Battlemage', None),    # Arc B-series (B580, B570)
 
     # Intel Processor N-series
     (r'Processor N\d{3}', 'Alder Lake-N', 12),

--- a/web/src/pages/cpu/gen/[gen].astro
+++ b/web/src/pages/cpu/gen/[gen].astro
@@ -356,22 +356,56 @@ function getDiffClass(diff: number | null): string {
           <CpuModelTable cpuModels={generationData.cpu_models} generationId={gen || ''} />
         </section>
 
-        {/* Pricing Links (Future) */}
-        <section class="pricing-section card">
-          <h2>Find This CPU</h2>
-          <p class="pricing-note">Search for {generationData.display_name} processors on popular marketplaces:</p>
-          <div class="pricing-links">
-            <a href={`https://www.ebay.com/sch/i.html?_nkw=intel+${gen}th+gen+cpu`} target="_blank" rel="noopener" class="pricing-link">
-              eBay
-            </a>
-            <a href={`https://www.amazon.com/s?k=intel+${gen}th+gen+processor`} target="_blank" rel="noopener" class="pricing-link">
-              Amazon
-            </a>
-            <a href={`https://www.newegg.com/p/pl?d=intel+${gen}th+gen`} target="_blank" rel="noopener" class="pricing-link">
-              Newegg
-            </a>
-          </div>
-        </section>
+        {/* Pricing Links - conditional based on generation type */}
+        {/^\d+$/.test(gen || '') ? (
+          <section class="pricing-section card">
+            <h2>Find This CPU</h2>
+            <p class="pricing-note">Search for {generationData.display_name} processors on popular marketplaces:</p>
+            <div class="pricing-links">
+              <a href={`https://www.ebay.com/sch/i.html?_nkw=intel+${gen}th+gen+cpu`} target="_blank" rel="noopener" class="pricing-link">
+                eBay
+              </a>
+              <a href={`https://www.amazon.com/s?k=intel+${gen}th+gen+processor`} target="_blank" rel="noopener" class="pricing-link">
+                Amazon
+              </a>
+              <a href={`https://www.newegg.com/p/pl?d=intel+${gen}th+gen`} target="_blank" rel="noopener" class="pricing-link">
+                Newegg
+              </a>
+            </div>
+          </section>
+        ) : gen === 'arc' ? (
+          <section class="pricing-section card">
+            <h2>Find Intel Arc GPUs</h2>
+            <p class="pricing-note">Search for Intel Arc discrete graphics cards:</p>
+            <div class="pricing-links">
+              <a href="https://www.ebay.com/sch/i.html?_nkw=intel+arc+gpu" target="_blank" rel="noopener" class="pricing-link">
+                eBay
+              </a>
+              <a href="https://www.amazon.com/s?k=intel+arc+graphics+card" target="_blank" rel="noopener" class="pricing-link">
+                Amazon
+              </a>
+              <a href="https://www.newegg.com/p/pl?d=intel+arc" target="_blank" rel="noopener" class="pricing-link">
+                Newegg
+              </a>
+            </div>
+          </section>
+        ) : gen?.startsWith('ultra') ? (
+          <section class="pricing-section card">
+            <h2>Find This CPU</h2>
+            <p class="pricing-note">Search for {generationData.display_name} processors on popular marketplaces:</p>
+            <div class="pricing-links">
+              <a href="https://www.ebay.com/sch/i.html?_nkw=intel+core+ultra+cpu" target="_blank" rel="noopener" class="pricing-link">
+                eBay
+              </a>
+              <a href="https://www.amazon.com/s?k=intel+core+ultra+processor" target="_blank" rel="noopener" class="pricing-link">
+                Amazon
+              </a>
+              <a href="https://www.newegg.com/p/pl?d=intel+core+ultra" target="_blank" rel="noopener" class="pricing-link">
+                Newegg
+              </a>
+            </div>
+          </section>
+        ) : null}
       </>
     ) : (
       <div class="loading-state">


### PR DESCRIPTION
## Summary

Fixes two related issues:
1. Arc GPUs not appearing on `/cpu/gen/arc/` page
2. "1th generation" appearing in pricing links for non-numeric generations

## Changes

### 1. Added Arc GPU Patterns to TypeScript Parser
**File:** `api/src/lib/cpu-parser.ts`

Added patterns for:
- Arc Alchemist (A-series: A770, A750, A380, A40 Pro)
- Arc Battlemage (B-series: B580, B570)

Uses architecture names matching the database schema (`Arc Alchemist`, `Arc Battlemage`) instead of cpu_generation numbers.

### 2. Fixed Pricing Links for Non-Numeric Generations
**File:** `web/src/pages/cpu/gen/[gen].astro`

Pricing links now intelligently handle different generation types:
- **Numeric generations** (6-14): Search for "intel 12th gen cpu"
- **Arc pages**: Search for "intel arc gpu" / "intel arc graphics card"
- **Core Ultra pages**: Search for "intel core ultra cpu"

No more nonsensical "arcth gen" or "ultra-1th gen" links!

### 3. Synced Python Backfill Script
**File:** `scripts/backfill-architectures.py`

Updated Arc patterns to match TypeScript parser:
- Changed to full architecture names (`Arc Alchemist`, `Arc Battlemage`)
- Set generation to `None` (Arc GPUs don't use cpu_generation numbers)

## Database Updates

Ran backfill script to fix existing data:
- Updated 5 records from `Alchemist` → `Arc Alchemist`
- Set `cpu_generation` to `NULL` for Arc GPUs
- Arc Alchemist now appears in filters API
- Verified `/api/results/arc-models` returns correct data

## Testing

- ✅ TypeScript compiles without errors
- ✅ Arc Alchemist appears in `/api/results/filters`
- ✅ `/api/results/arc-models?architecture=Arc+Alchemist` returns A40 Pro data
- ✅ `/api/results/generation-detail?generation=arc` works correctly

## After Merge

Once deployed, Arc GPUs will appear in:
- Main dashboard architecture filters
- `/cpu/gen/arc/` generation page
- `/gpu/arc/alchemist/` architecture page
- CPU model search/filters

Pricing links will work correctly for all generation types.