### PR TITLE
Fix generation extraction for 4-digit model numbers

### DIFF
--- a/api/src/lib/cpu-parser.ts
+++ b/api/src/lib/cpu-parser.ts
@@ -121,7 +121,9 @@ export function parseCPU(cpuRaw: string): CPUInfo {
     const genMatch = model.match(/^(\d{4,5})/);
     if (genMatch) {
       const genStr = genMatch[1];
-      generation = parseInt(genStr.slice(0, -3), 10);
+      // 4-digit mobile (1165G7) -> first 2 digits = "11"
+      // 5-digit desktop (12600K) -> first 2 digits = "12"
+      generation = parseInt(genStr.slice(0, 2), 10);
     }
   }
 


### PR DESCRIPTION
## Problem
Mobile CPUs with 4-digit model numbers (i7-1165G7, i3-1115G4, i7-1065G7) were showing as "1st Gen" in filters instead of their correct generation (11th, 10th).

## Root Cause
Generation extraction used `slice(0, -3)` which works for 5-digit models but fails for 4-digit:
- `"12600".slice(0,-3)` = `"12"` ✓ (12th gen)
- `"1165".slice(0,-3)` = `"1"` ✗ (should be 11th gen)

## Solution
Changed to `slice(0, 2)` which works for both:
- 4-digit mobile: `"1165"` → first 2 chars = `"11"` → 11th gen ✓
- 5-digit desktop: `"12600"` → first 2 chars = `"12"` → 12th gen ✓

## Database Updates
Updated existing incorrect entries via SQL:
- **5 Ice Lake entries**: gen 1 → 10
- **15 Tiger Lake entries**: gen 1 → 11

## Testing
```bash
# Before fix
i7-1165G7 -> gen 1 ✗
i7-1065G7 -> gen 1 ✗

# After fix
i7-1165G7 -> gen 11 ✓
i7-1065G7 -> gen 10 ✓
i5-12600K -> gen 12 ✓ (still works)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)