### PR TITLE
Reorganize CPU generation page layout with ECC support

### DIFF
--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -116,3 +116,15 @@ CREATE INDEX IF NOT EXISTS idx_concurrency_vendor ON concurrency_results(vendor)
 CREATE INDEX IF NOT EXISTS idx_arch_pattern ON cpu_architectures(pattern);
 CREATE INDEX IF NOT EXISTS idx_arch_sort_order ON cpu_architectures(sort_order);
 CREATE INDEX IF NOT EXISTS idx_arch_vendor ON cpu_architectures(vendor);
+
+-- CPU features table for per-CPU metadata (ECC support, etc.)
+-- Tracks features that vary by specific CPU model, not by architecture
+CREATE TABLE IF NOT EXISTS cpu_features (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cpu_raw TEXT UNIQUE NOT NULL,   -- Exact CPU string from benchmark (matches benchmark_results.cpu_raw)
+    ecc_support BOOLEAN DEFAULT 0,  -- Whether this CPU supports ECC memory
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_cpu_features_cpu_raw ON cpu_features(cpu_raw);

--- a/web/src/components/generation/ArchitectureCard.astro
+++ b/web/src/components/generation/ArchitectureCard.astro
@@ -25,6 +25,7 @@ interface CpuModel {
   avg_fps: number;
   fps_per_watt: number | null;
   score: number | null;
+  ecc_support?: boolean;
 }
 
 interface Props {
@@ -113,7 +114,10 @@ function stripCpuBranding(cpu: string): string {
                   <span class="variant-cpus-label">Tested CPUs using this die:</span>
                   <div class="variant-cpus-list">
                     {variantCpus.map(cpu => (
-                      <span class="variant-cpu-chip">{stripCpuBranding(cpu.cpu_raw)}</span>
+                      <span class="variant-cpu-chip">
+                        {stripCpuBranding(cpu.cpu_raw)}
+                        {cpu.ecc_support && <span class="ecc-badge">ECC</span>}
+                      </span>
                     ))}
                   </div>
                 </div>
@@ -253,13 +257,26 @@ function stripCpuBranding(cpu: string): string {
   }
 
   .variant-cpu-chip {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
     font-size: 0.75rem;
     padding: 0.1875rem 0.5rem;
     background: var(--color-bg-secondary);
     border: 1px solid var(--color-border);
     border-radius: 0.25rem;
     color: var(--color-text);
+  }
+
+  .ecc-badge {
+    font-size: 0.625rem;
+    font-weight: 600;
+    padding: 0.0625rem 0.3125rem;
+    background: rgba(34, 197, 94, 0.15);
+    color: #22c55e;
+    border-radius: 0.1875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.025em;
   }
 
   .arch-name {

--- a/web/src/pages/cpu/gen/[gen].astro
+++ b/web/src/pages/cpu/gen/[gen].astro
@@ -276,23 +276,22 @@ function getDiffClass(diff: number | null): string {
           )}
         </section>
 
-        {/* Architecture & Codec Grid */}
-        <div class="info-grid">
-          <section class="card">
-            <h2>Architecture</h2>
-            <ArchitectureCard
-              architecture={generationData.architecture}
-              variants={generationData.architecture_variants}
-              hasMultipleVariants={generationData.has_multiple_variants}
-              cpuModels={generationData.cpu_models}
-            />
-          </section>
+        {/* Architecture */}
+        <section class="card">
+          <h2>Architecture</h2>
+          <ArchitectureCard
+            architecture={generationData.architecture}
+            variants={generationData.architecture_variants}
+            hasMultipleVariants={generationData.has_multiple_variants}
+            cpuModels={generationData.cpu_models}
+          />
+        </section>
 
-          <section class="card">
-            <h2>Codec Support</h2>
-            <CodecMatrix codecSupport={generationData.codec_support} />
-          </section>
-        </div>
+        {/* Codec Support */}
+        <section class="card">
+          <h2>Codec Support</h2>
+          <CodecMatrix codecSupport={generationData.codec_support} />
+        </section>
 
         {/* Benchmark Data */}
         <section class="benchmark-section card">
@@ -632,18 +631,7 @@ function getDiffClass(diff: number | null): string {
     border-radius: 0.25rem;
   }
 
-  /* Info Grid */
-  .info-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
-  }
-
   @media (max-width: 768px) {
-    .info-grid {
-      grid-template-columns: 1fr;
-    }
-
     .page-header {
       grid-template-columns: 1fr;
       text-align: center;


### PR DESCRIPTION
## Summary
- Change Architecture and Codec Support sections from 2-column grid to full-width stacked cards
- Move Codec Support section to appear before Benchmark Data section
- Add `cpu_features` database table for per-CPU metadata (ECC support tracking)
- Update generation-detail API to return `ecc_support` for each CPU model
- Add green ECC badge next to tested CPUs that support ECC memory

## Visual Change
**Before:** Architecture and Codec Support side-by-side in 2-column grid
**After:** Full-width stacked cards (Architecture → Codec Support → Benchmark Data)

## Database Migration Required
Run on Turso to create the new `cpu_features` table:
```sql
CREATE TABLE IF NOT EXISTS cpu_features (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    cpu_raw TEXT UNIQUE NOT NULL,
    ecc_support BOOLEAN DEFAULT 0,
    created_at TEXT DEFAULT (datetime('now')),
    updated_at TEXT DEFAULT (datetime('now'))
);
CREATE INDEX IF NOT EXISTS idx_cpu_features_cpu_raw ON cpu_features(cpu_raw);
```

## Test plan
- [ ] Verify layout renders correctly on desktop and mobile
- [ ] Confirm section order: TL;DR → Architecture → Codec Support → Benchmark Data
- [ ] Test ECC badge appears when `cpu_features.ecc_support = 1` for a CPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)