### PR TITLE
Display die variants side-by-side on desktop

### DIFF
--- a/web/src/components/generation/ArchitectureCard.astro
+++ b/web/src/components/generation/ArchitectureCard.astro
@@ -196,9 +196,15 @@ function stripCpuBranding(cpu: string): string {
   }
 
   .variants-container {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     gap: 1rem;
+  }
+
+  @media (max-width: 900px) {
+    .variants-container {
+      grid-template-columns: 1fr;
+    }
   }
 
   .variant-card {
@@ -206,6 +212,8 @@ function stripCpuBranding(cpu: string): string {
     border: 1px solid var(--color-border);
     border-radius: 0.375rem;
     padding: 1rem;
+    display: flex;
+    flex-direction: column;
   }
 
   .variant-header {


### PR DESCRIPTION
## Summary
When a CPU generation has multiple die variants (e.g., Coffee Lake with UHD 630 and UHD 610), display them in a 2-column grid on desktop instead of stacked vertically.

## Changes
- `.variants-container` uses CSS grid with `repeat(2, 1fr)` on desktop (>900px)
- Falls back to single column on mobile/tablet (<900px)
- `.variant-card` uses flex column for consistent height handling

## Screenshot context
This improves the 8th Gen page which shows 2 die variants (CFL with 24 EU vs 24 EU but different core counts).

## Test plan
- [ ] View generation page with multiple die variants (e.g., /cpu/gen/8)
- [ ] Verify cards appear side-by-side on desktop
- [ ] Verify cards stack vertically on mobile (<900px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)