### PR TITLE
Fix: Increase KV lock TTL from 30s to 60s (Cloudflare minimum)

### DIFF
--- a/api/src/lib/lock.ts
+++ b/api/src/lib/lock.ts
@@ -4,7 +4,7 @@
  */
 
 const LOCK_KEY = 'benchmarks-write-lock';
-const LOCK_TTL = 30; // seconds
+const LOCK_TTL = 60; // seconds (minimum allowed by Cloudflare KV)
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 1000; // ms
 


### PR DESCRIPTION
## Summary

Fixes submission failures caused by invalid KV expiration TTL.

## Problem

Submissions were failing with error:
```
KV PUT failed: 400 Invalid expiration_ttl of 30. Expiration TTL must be at least 60.
```

This was introduced in commit 48e3755 during the Turso → R2 refactor.

## Root Cause

The `LOCK_TTL` constant in `api/src/lib/lock.ts` was set to 30 seconds, but Cloudflare KV requires a minimum expiration TTL of 60 seconds.

## Solution

Increased `LOCK_TTL` from 30 to 60 seconds to meet Cloudflare KV's minimum requirement.

## Testing

After merge and deployment:
- [ ] Verify submissions complete successfully
- [ ] Check Worker logs for no KV PUT errors
- [ ] Confirm lock mechanism prevents race conditions

## Impact

- **Risk:** Low - Only increases lock duration from 30s to 60s
- **Scope:** Affects all pending submissions using the lock mechanism
- **Files Changed:** `api/src/lib/lock.ts` (1 line)