### PR TITLE
Fix: Use percentile-based scoring on dashboard to match leaderboard

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -2211,7 +2211,7 @@ cd quicksync_calc
     });
   }
 
-  // Fetch CPU scores (computed from local data)
+  // Fetch CPU scores (computed from local data using percentile ranking)
   async function fetchCpuScores() {
     try {
       // Group results by CPU
@@ -2221,11 +2221,35 @@ cd quicksync_calc
         byCpu[r.cpu_raw].push(r);
       }
 
-      // Get max values for normalization
-      const allFps = benchmarkData.results.map(r => r.avg_fps);
-      const allEfficiency = benchmarkData.results.filter(r => r.fps_per_watt !== null).map(r => r.fps_per_watt);
-      const maxFps = Math.max(...allFps);
-      const maxEfficiency = Math.max(...allEfficiency);
+      // Calculate average FPS and efficiency per CPU
+      const cpuAvgFps = [];
+      const cpuAvgEfficiency = [];
+
+      for (const [cpu, results] of Object.entries(byCpu)) {
+        const avgFps = results.reduce((sum, r) => sum + r.avg_fps, 0) / results.length;
+        cpuAvgFps.push({ cpu, fps: avgFps });
+
+        const effResults = results.filter(r => r.fps_per_watt !== null);
+        if (effResults.length > 0) {
+          const avgEfficiency = effResults.reduce((sum, r) => sum + r.fps_per_watt, 0) / effResults.length;
+          cpuAvgEfficiency.push({ cpu, eff: avgEfficiency });
+        }
+      }
+
+      // Sort by FPS and efficiency (ascending for percentile calculation)
+      cpuAvgFps.sort((a, b) => a.fps - b.fps);
+      cpuAvgEfficiency.sort((a, b) => a.eff - b.eff);
+
+      // Calculate percentile ranks (0-100 based on position in sorted array)
+      const fpsPercentile = {};
+      cpuAvgFps.forEach((item, idx) => {
+        fpsPercentile[item.cpu] = Math.round((idx / (cpuAvgFps.length - 1)) * 100);
+      });
+
+      const effPercentile = {};
+      cpuAvgEfficiency.forEach((item, idx) => {
+        effPercentile[item.cpu] = Math.round((idx / (cpuAvgEfficiency.length - 1)) * 100);
+      });
 
       // Get architecture codec support lookup
       const archCodecs = {};
@@ -2240,15 +2264,8 @@ cd quicksync_calc
       const scores = {};
 
       for (const [cpu, results] of Object.entries(byCpu)) {
-        const avgFps = results.reduce((sum, r) => sum + r.avg_fps, 0) / results.length;
-        const effResults = results.filter(r => r.fps_per_watt !== null);
-        const avgEfficiency = effResults.length > 0
-          ? effResults.reduce((sum, r) => sum + r.fps_per_watt, 0) / effResults.length
-          : 0;
-
-        // Normalize to 0-100
-        const fpsScore = (avgFps / maxFps) * 100;
-        const efficiencyScore = maxEfficiency > 0 ? (avgEfficiency / maxEfficiency) * 100 : 0;
+        const perfScore = fpsPercentile[cpu] ?? 50;
+        const effScore = effPercentile[cpu] ?? 50;
 
         // Codec support score (based on architecture)
         const arch = results[0]?.architecture;
@@ -2261,7 +2278,7 @@ cd quicksync_calc
         }
 
         // Weighted average: 40% performance + 35% efficiency + 25% codec support
-        const score = Math.round(fpsScore * 0.4 + efficiencyScore * 0.35 + codecScore * 0.25);
+        const score = Math.round(perfScore * 0.4 + effScore * 0.35 + codecScore * 0.25);
         scores[cpu] = Math.min(100, Math.max(0, score));
       }
 


### PR DESCRIPTION
## Summary

Fixes inconsistent CPU scores between the dashboard results table and the leaderboard/CPU detail pages.

**Before:** i5-13600K showed score of **27** on dashboard  
**After:** i5-13600K shows score of **89** across all pages ✓

## Problem

The dashboard was using **linear normalization** to calculate CPU scores:
```javascript
const fpsScore = (avgFps / maxFps) * 100;  // Results in low scores
```

While the leaderboard and CPU detail pages were using **percentile ranking**:
```javascript
const fpsPercentile = Math.round((idx / (cpuAvgFps.length - 1)) * 100);
```

This caused the same CPU to show dramatically different scores depending on which page you viewed.

## Solution

Updated `web/src/pages/index.astro` (lines 2214-2289) to use the same percentile-based scoring algorithm as the leaderboard:

1. Calculate per-CPU averages for FPS and efficiency
2. Sort CPUs by these metrics (ascending)
3. Assign percentile rank based on position in sorted array (0-100)
4. Combine: 40% performance + 35% efficiency + 25% codec support

## Verification

Tested across all views with multiple CPUs:
- Dashboard: i5-13600K = 89, i7-12700K = 87, i5-1240P = 83 ✓
- Leaderboard: i5-13600K = 89, i7-12700K = 87, i5-1240P = 83 ✓
- CPU Detail: i5-13600K = 89, i7-12700K = 87, i5-1240P = 83 ✓

All pages now show consistent scores using percentile ranking.

## Test plan

- [x] Load dashboard at `/` and verify i5-13600K score = 89
- [x] Load leaderboard at `/leaderboard` and verify score = 89
- [x] Load CPU detail at `/cpu/gen/13/` and verify score = 89
- [x] Verify other CPUs show matching scores across all pages