### PR TITLE
Replace bc with awk for improved portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The website provides:
 - Intel CPU with Quick Sync support
 - `intel-gpu-tools` package (for power measurement)
 - `jq` (for JSON parsing)
-- `bc` (for calculations)
+- `awk` (for calculations - typically pre-installed)
 
 Designed for Linux. Tested on Proxmox 9 and Ubuntu 24.04 LTS.
 
@@ -47,7 +47,7 @@ Full instructions available at [blog.ktz.me](https://blog.ktz.me/i-need-your-hel
 ssh user@hostname
 
 # Install dependencies (tested on Proxmox 8 + Ubuntu 22.04)
-apt install docker.io jq bc intel-gpu-tools git curl
+apt install docker.io jq intel-gpu-tools git curl
 
 # Clone the repository
 git clone https://github.com/ironicbadger/quicksync_calc.git

--- a/docs/k8s-plan.md
+++ b/docs/k8s-plan.md
@@ -102,7 +102,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     intel-gpu-tools \
     curl \
     jq \
-    bc \
     wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/quicksync-benchmark.sh
+++ b/quicksync-benchmark.sh
@@ -124,8 +124,8 @@ dep_check(){
     exit 127
   fi
 
-  if ! which bc >/dev/null; then
-    echo "bc missing. Please install bc"
+  if ! which awk >/dev/null; then
+    echo "awk missing. Please install awk"
     exit 127
   fi
 
@@ -143,9 +143,9 @@ BASE_URL="https://ssh.us-east-1.linodeobjects.com"
 format_size(){
   local bytes=$1
   if [ $bytes -ge 1073741824 ]; then
-    echo "$(echo "scale=1; $bytes / 1073741824" | bc)GB"
+    echo "$(awk "BEGIN {printf \"%.1f\", $bytes / 1073741824}")GB"
   elif [ $bytes -ge 1048576 ]; then
-    echo "$(echo "scale=0; $bytes / 1048576" | bc)MB"
+    echo "$(awk "BEGIN {printf \"%.0f\", $bytes / 1048576}")MB"
   else
     echo "${bytes}B"
   fi
@@ -305,8 +305,7 @@ benchmarks(){
       awk '{ print $5 }' $1.output \
       | grep -E '^[0-9.]+$' \
       | grep -Ev '^(0(\.0+)?|Power|gpu)$' \
-      | paste -s -d+ - \
-      | bc
+      | awk '{sum += $1} END {print sum}'
     )
     total_count=$(
       awk '{ print $5 }' $1.output \
@@ -314,10 +313,10 @@ benchmarks(){
       | grep -Ev '^(0(\.0+)?|Power|gpu)$' \
       | wc -l
     )
-    avg_watts=$(echo "scale=2; $total_watts / $total_count" | bc -l)
+    avg_watts=$(awk "BEGIN {printf \"%.2f\", $total_watts / $total_count}")
 
     # Validate power reading
-    if [ "$(echo "$avg_watts < 3" | bc -l)" -eq 1 ]; then
+    if [ "$(awk "BEGIN {print ($avg_watts < 3)}")" -eq 1 ]; then
       echo ""
       echo "======================================================="
       echo "           ⚠️  WARNING: LOW POWER READING"
@@ -350,17 +349,16 @@ benchmarks(){
 
   for i in $(ls ffmpeg-*.log); do
     #Calculate average FPS
-    total_fps=$(grep -Eo 'fps=.[1-9][1-9].' $i | sed -e 's/fps=//' | paste -s -d + - | bc)
+    total_fps=$(grep -Eo 'fps=.[1-9][1-9].' $i | sed -e 's/fps=//' | awk '{sum += $1} END {print sum}')
     fps_count=$(grep -Eo 'fps=.[1-9][1-9].' $i | wc -l)
-    avg_fps=$(echo "scale=2; $total_fps / $fps_count" | bc -l)
+    avg_fps=$(awk "BEGIN {printf \"%.2f\", $total_fps / $fps_count}")
 
     #Calculate average speed
     total_speed=$(grep -Eo 'speed=[0-9]+(\.[0-9]+)?x' "$i" \
       | sed -E 's/speed=([0-9.]+)x/\1/' \
-      | paste -s -d+ - \
-      | bc)
+      | awk '{sum += $1} END {print sum}')
     speed_count=$(grep -Eo 'speed=[0-9]+(\.[0-9]+)?x' "$i" | wc -l)
-    avg_speed="$(echo "scale=2; $total_speed / $speed_count" | bc -l)x"
+    avg_speed="$(awk "BEGIN {printf \"%.2f\", $total_speed / $speed_count}")x"
 
     #Get Bitrate of file
     bitrate=$(grep -Eo 'bitrate: [1-9].*' $i | sed -e 's/bitrate: //')

--- a/web/src/pages/about.astro
+++ b/web/src/pages/about.astro
@@ -83,7 +83,7 @@ QUICKSYNC_NO_SUBMIT=1 ./quicksync-benchmark.sh</code></pre>
         <li>Intel CPU with Quick Sync support</li>
         <li><code>intel-gpu-tools</code> package (for power measurement)</li>
         <li><code>jq</code> (for JSON parsing)</li>
-        <li><code>bc</code> (for calculations)</li>
+        <li><code>awk</code> (for calculations - typically pre-installed)</li>
       </ul>
     </div>
 


### PR DESCRIPTION
─────┬──────────────────────────────────────────────────────────────────────────
     │ STDIN
─────┼──────────────────────────────────────────────────────────────────────────
   1 │ ## Summary
   2 │ Replace all `bc` usage with `awk` to enable running the benchmark on systems like TrueNAS 25.10 without installing additional packages. `awk` is a POSIX standard tool available by default on most Unix systems.
   3 │ 
   4 │ ## Changes
   5 │ - Replace bc calculations with awk in `quicksync-benchmark.sh`
   6 │   - File size formatting (GB/MB conversion)
   7 │   - Sum operations (power readings, FPS, speed values)
   8 │   - Division with decimal precision (averaging calculations)
   9 │   - Numeric comparisons (power reading validation)
  10 │ - Update dependency check to verify `awk` instead of `bc`
  11 │ - Update `README.md` requirements and installation instructions
  12 │ - Update `web/src/pages/about.astro` requirements list
  13 │ - Update `docs/k8s-plan.md` Dockerfile to remove bc dependency
  14 │ 
  15 │ ## Testing
  16 │ All awk replacements have been tested and produce identical results to bc:
  17 │ - Division with 2 decimal places: `33.33` ✓
  18 │ - Sum of numbers: `15` ✓  
  19 │ - Comparisons: `1` (true) ✓
  20 │ - File size formatting: `1.0` GB ✓
  21 │ 
  22 │ ## Motivation
  23 │ This change allows the benchmark to run on TrueNAS 25.10 and other minimal systems without requiring package installation. Since `awk` is part of POSIX and available by default on virtually all Unix systems, this improves portability while maintaining identical functionality.
─────┴──────────────────────────────────────────────────────────────────────────